### PR TITLE
Use a common base object and trait

### DIFF
--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -1,8 +1,8 @@
-use crate::{Link, STAC_VERSION};
+use crate::core::{Core, CoreStruct};
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value};
 
-pub(crate) const CATALOG_TYPE: &str = "Catalog";
+/// The type field for Catalogs.
+pub const CATALOG_TYPE: &str = "Catalog";
 
 /// A STAC Catalog object represents a logical group of other Catalog,
 /// Collection, and Item objects.
@@ -18,42 +18,13 @@ pub(crate) const CATALOG_TYPE: &str = "Catalog";
 /// to build a searchable index.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Catalog {
-    /// Set to Catalog if this Catalog only implements the Catalog spec.
-    #[serde(rename = "type")]
-    pub type_: String,
-
-    /// The STAC version the Catalog implements.
-    #[serde(rename = "stac_version")]
-    pub version: String,
-
-    /// A list of extension identifiers the Catalog implements.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub extensions: Option<Vec<String>>,
-
-    /// Identifier for the Catalog.
-    pub id: String,
-
-    /// A short descriptive one-line title for the Catalog.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
-
-    /// Detailed multi-line description to fully explain the Catalog.
-    ///
-    /// [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation.
-    pub description: String,
-
-    /// A list of references to other documents.
-    pub links: Vec<Link>,
-
-    /// Addititional fields on the Catalog.
     #[serde(flatten)]
-    pub additional_fields: Map<String, Value>,
+    core: CoreStruct,
 
-    /// The href from which the Catalog was read.
-    ///
-    /// Not serialized.
-    #[serde(skip)]
-    pub(crate) href: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+
+    description: String,
 }
 
 impl Catalog {
@@ -62,41 +33,74 @@ impl Catalog {
     /// # Examples
     ///
     /// ```
-    /// # use stac::Catalog;
+    /// use stac::{Catalog, Core};
     /// let catalog = Catalog::new("an-id");
-    /// assert_eq!(catalog.id, "an-id");
+    /// assert_eq!(catalog.id(), "an-id");
     /// ```
     pub fn new<S: ToString>(id: S) -> Catalog {
         Catalog {
-            type_: CATALOG_TYPE.to_string(),
-            version: STAC_VERSION.to_string(),
-            extensions: None,
-            id: id.to_string(),
+            core: CoreStruct::new(CATALOG_TYPE, id),
             title: None,
             description: String::new(),
-            links: Vec::new(),
-            additional_fields: Map::new(),
-            href: None,
         }
     }
+
+    /// Returns a reference to this Catalog's title.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac::Catalog;
+    /// let catalog = Catalog::new("an-id");
+    /// assert!(catalog.title().is_none());
+    /// ```
+    pub fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    /// Returns a reference to this Catalog's description.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac::Catalog;
+    /// let catalog = Catalog::new("an-id");
+    /// assert_eq!(catalog.description(), "");
+    /// ```
+    pub fn description(&self) -> &str {
+        &self.description
+    }
 }
+
+impl AsRef<CoreStruct> for Catalog {
+    fn as_ref(&self) -> &CoreStruct {
+        &self.core
+    }
+}
+
+impl AsMut<CoreStruct> for Catalog {
+    fn as_mut(&mut self) -> &mut CoreStruct {
+        &mut self.core
+    }
+}
+
+impl Core for Catalog {}
 
 #[cfg(test)]
 mod tests {
     use super::Catalog;
-    use crate::STAC_VERSION;
+    use crate::{Core, STAC_VERSION};
 
     #[test]
     fn new() {
         let catalog = Catalog::new("an-id");
-        assert_eq!(catalog.type_, "Catalog");
-        assert_eq!(catalog.version, STAC_VERSION);
-        assert!(catalog.extensions.is_none());
-        assert_eq!(catalog.id, "an-id");
-        assert!(catalog.title.is_none());
-        assert_eq!(catalog.description, "");
-        assert!(catalog.links.is_empty());
-        assert!(catalog.additional_fields.is_empty());
+        assert!(catalog.title().is_none());
+        assert_eq!(catalog.description(), "");
+        assert_eq!(catalog.type_(), "Catalog");
+        assert_eq!(catalog.version(), STAC_VERSION);
+        assert!(catalog.extensions().is_none());
+        assert_eq!(catalog.id(), "an-id");
+        assert!(catalog.links().is_empty());
     }
 
     #[test]
@@ -106,6 +110,7 @@ mod tests {
         assert!(value.get("stac_extensions").is_none());
         assert!(value.get("title").is_none());
     }
+
     mod roundtrip {
         use super::Catalog;
         use crate::tests::roundtrip;

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -1,9 +1,13 @@
-use crate::{Asset, Extent, Link, Provider, STAC_VERSION};
+use crate::{
+    core::{Core, CoreStruct},
+    Asset, Extent, Provider,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::collections::HashMap;
 
-pub(crate) const COLLECTION_TYPE: &str = "Collection";
+/// The type field for Collections.
+pub const COLLECTION_TYPE: &str = "Collection";
 
 /// The STAC Collection Specification defines a set of common fields to describe
 /// a group of Items that share properties and metadata.
@@ -19,69 +23,29 @@ pub(crate) const COLLECTION_TYPE: &str = "Collection";
 /// STAC Catalog.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Collection {
-    /// Must be set to Collection to be a valid Collection.
-    #[serde(rename = "type")]
-    pub type_: String,
-
-    /// The STAC version the Collection implements.
-    #[serde(rename = "stac_version")]
-    pub version: String,
-
-    /// A list of extension identifiers the Collection implements.
-    #[serde(rename = "stac_extensions")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub extensions: Option<Vec<String>>,
-
-    /// Identifier for the Collection that is unique across the provider.
-    pub id: String,
-
-    /// A short descriptive one-line title for the Collection.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
-
-    /// Detailed multi-line description to fully explain the Collection.
-    ///
-    /// [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation.
-    pub description: String,
-
-    /// List of keywords describing the Collection.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub keywords: Option<Vec<String>>,
-
-    /// Collection's license(s), either a SPDX [License identifier](https://spdx.org/licenses/), `various` if multiple licenses apply or `proprietary` for all other cases.
-    pub license: String,
-
-    /// A list of providers, which may include all organizations capturing or
-    /// processing the data or the hosting provider.
-    ///
-    /// Providers should be listed in chronological order with the most recent
-    /// provider being the last element of the list.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub providers: Option<Vec<Provider>>,
-
-    /// Spatial and temporal extents.
-    pub extent: Extent,
-
-    /// A map of property summaries, either a set of values, a range of values or a JSON Schema.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub summaries: Option<Map<String, Value>>,
-
-    /// A list of references to other documents.
-    pub links: Vec<Link>,
-
-    /// Dictionary of asset objects that can be downloaded, each with a unique key.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub assets: Option<HashMap<String, Asset>>,
-
-    /// Additional fields on the `Collection`.
     #[serde(flatten)]
-    pub additional_fields: Map<String, Value>,
+    core: CoreStruct,
 
-    /// The href from which the Collection was read.
-    ///
-    /// Not serialized.
-    #[serde(skip)]
-    pub(crate) href: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+
+    description: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    keywords: Option<Vec<String>>,
+
+    license: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    providers: Option<Vec<Provider>>,
+
+    extent: Extent,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    summaries: Option<Map<String, Value>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    assets: Option<HashMap<String, Asset>>,
 }
 
 impl Collection {
@@ -90,16 +54,13 @@ impl Collection {
     /// # Examples
     ///
     /// ```
-    /// # use stac::Collection;
+    /// use stac::{Collection, Core};
     /// let collection = Collection::new("an-id");
-    /// assert_eq!(collection.id, "an-id");
+    /// assert_eq!(collection.id(), "an-id");
     /// ```
     pub fn new<S: ToString>(id: S) -> Collection {
         Collection {
-            type_: COLLECTION_TYPE.to_string(),
-            version: STAC_VERSION.to_string(),
-            extensions: None,
-            id: id.to_string(),
+            core: CoreStruct::new(COLLECTION_TYPE, id),
             title: None,
             description: String::new(),
             keywords: None,
@@ -107,35 +68,136 @@ impl Collection {
             providers: None,
             extent: Extent::default(),
             summaries: None,
-            links: Vec::new(),
             assets: None,
-            additional_fields: Map::new(),
-            href: None,
         }
     }
+
+    /// Returns a reference to this Collection's title.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac::Collection;
+    /// let collection = Collection::new("an-id");
+    /// assert!(collection.title().is_none());
+    /// ```
+    pub fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    /// Returns a reference to this Collection's description.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac::Collection;
+    /// let collection = Collection::new("an-id");
+    /// assert_eq!(collection.description(), "");
+    /// ```
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    /// Returns a reference to this Collection's license.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac::Collection;
+    /// let collection = Collection::new("an-id");
+    /// assert_eq!(collection.license(), "");
+    /// ```
+    pub fn license(&self) -> &str {
+        &self.license
+    }
+
+    /// Returns a reference to this Collection's providers.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac::Collection;
+    /// let collection = Collection::new("an-id");
+    /// assert!(collection.providers().is_none());
+    /// ```
+    pub fn providers(&self) -> Option<&[Provider]> {
+        self.providers.as_deref()
+    }
+
+    /// Returns a reference to this Collection's extent.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac::{Collection, Extent};
+    /// let collection = Collection::new("an-id");
+    /// assert_eq!(collection.extent(), &Extent::default());
+    /// ```
+    pub fn extent(&self) -> &Extent {
+        &self.extent
+    }
+
+    /// Returns a reference to this Collection's summaries.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac::Collection;
+    /// let collection = Collection::new("an-id");
+    /// assert!(collection.summaries().is_none());
+    /// ```
+    pub fn summaries(&self) -> Option<&Map<String, Value>> {
+        self.summaries.as_ref()
+    }
+
+    /// Returns a reference to this Collection's assets.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac::Collection;
+    /// let collection = Collection::new("an-id");
+    /// assert!(collection.assets().is_none());
+    /// ```
+    pub fn assets(&self) -> Option<&HashMap<String, Asset>> {
+        self.assets.as_ref()
+    }
 }
+
+impl AsRef<CoreStruct> for Collection {
+    fn as_ref(&self) -> &CoreStruct {
+        &self.core
+    }
+}
+
+impl AsMut<CoreStruct> for Collection {
+    fn as_mut(&mut self) -> &mut CoreStruct {
+        &mut self.core
+    }
+}
+
+impl Core for Collection {}
 
 #[cfg(test)]
 mod tests {
     use super::Collection;
-    use crate::{Extent, STAC_VERSION};
+    use crate::{Core, Extent, STAC_VERSION};
 
     #[test]
     fn new() {
         let collection = Collection::new("an-id");
-        assert_eq!(collection.type_, "Collection");
-        assert_eq!(collection.version, STAC_VERSION);
-        assert!(collection.extensions.is_none());
-        assert_eq!(collection.id, "an-id");
-        assert!(collection.title.is_none());
-        assert_eq!(collection.description, "");
-        assert_eq!(collection.license, "");
-        assert!(collection.providers.is_none());
-        assert_eq!(collection.extent, Extent::default());
-        assert!(collection.summaries.is_none());
-        assert!(collection.links.is_empty());
-        assert!(collection.assets.is_none());
-        assert!(collection.additional_fields.is_empty());
+        assert!(collection.title().is_none());
+        assert_eq!(collection.description(), "");
+        assert_eq!(collection.license(), "");
+        assert!(collection.providers().is_none());
+        assert_eq!(collection.extent(), &Extent::default());
+        assert!(collection.summaries().is_none());
+        assert!(collection.assets().is_none());
+        assert_eq!(collection.type_(), "Collection");
+        assert_eq!(collection.version(), STAC_VERSION);
+        assert!(collection.extensions().is_none());
+        assert_eq!(collection.id(), "an-id");
+        assert!(collection.links().is_empty());
     }
 
     #[test]

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,0 +1,123 @@
+use crate::{Link, STAC_VERSION};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// A trait derived by all three core STAC object types.
+///
+/// This trait provides access to the field shared by all three STAC object types.
+pub trait Core: AsRef<CoreStruct> + AsMut<CoreStruct> {
+    /// Returns a reference to this structure's type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac::{Core, Catalog};
+    /// let catalog = Catalog::new("an-id");
+    /// assert_eq!(catalog.type_(), "Catalog");
+    /// ```
+    fn type_(&self) -> &str {
+        &self.as_ref().type_
+    }
+
+    /// Returns a reference to this structure's STAC version.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac::{Core, Catalog};
+    /// let catalog = Catalog::new("an-id");
+    /// assert_eq!(catalog.version(), stac::STAC_VERSION);
+    /// ```
+    fn version(&self) -> &str {
+        &self.as_ref().version
+    }
+
+    /// Returns a reference to this structure's extensions.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac::{Core, Catalog};
+    /// let catalog = Catalog::new("an-id");
+    /// assert!(catalog.extensions().is_none());
+    /// ```
+    fn extensions(&self) -> Option<&[String]> {
+        self.as_ref().extensions.as_deref()
+    }
+
+    /// Returns a reference to this structure's id.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac::{Core, Catalog};
+    /// let catalog = Catalog::new("an-id");
+    /// assert_eq!(catalog.id(), "an-id");
+    /// ```
+    fn id(&self) -> &str {
+        &self.as_ref().id
+    }
+
+    /// Returns a reference to this structure's links.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac::{Core, Catalog};
+    /// let catalog = Catalog::new("an-id");
+    /// assert!(catalog.links().is_empty());
+    /// ```
+    fn links(&self) -> &[Link] {
+        &self.as_ref().links
+    }
+
+    /// Returns a reference to this structure's additional fields.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac::{Core, Catalog};
+    /// let catalog = Catalog::new("an-id");
+    /// assert!(catalog.additional_fields().is_empty());
+    /// ```
+    fn additional_fields(&self) -> &Map<String, Value> {
+        &self.as_ref().additional_fields
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct CoreStruct {
+    #[serde(rename = "type")]
+    type_: String,
+
+    #[serde(rename = "stac_version")]
+    version: String,
+
+    #[serde(rename = "stac_extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extensions: Option<Vec<String>>,
+
+    id: String,
+
+    links: Vec<Link>,
+
+    #[serde(flatten)]
+    additional_fields: Map<String, Value>,
+
+    #[serde(skip)]
+    pub(crate) href: Option<String>,
+}
+
+impl CoreStruct {
+    pub(crate) fn new<A: ToString, B: ToString>(type_: A, id: B) -> CoreStruct {
+        CoreStruct {
+            type_: type_.to_string(),
+            version: STAC_VERSION.to_string(),
+            extensions: None,
+            id: id.to_string(),
+            links: Vec::new(),
+            additional_fields: Map::new(),
+            href: None,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,6 @@
 //! let item = Item::new("id");
 //! let catalog = Catalog::new("id");
 //! let collection = Catalog::new("id");
-//! assert_eq!(item.version, "1.0.0");
 //! ```
 //!
 //! # Full specification compliance
@@ -88,6 +87,7 @@
 mod asset;
 mod catalog;
 mod collection;
+mod core;
 mod error;
 mod extent;
 mod item;
@@ -99,12 +99,13 @@ mod reader;
 pub mod utils;
 
 pub use {
+    crate::core::Core,
     asset::Asset,
-    catalog::Catalog,
-    collection::Collection,
+    catalog::{Catalog, CATALOG_TYPE},
+    collection::{Collection, COLLECTION_TYPE},
     error::Error,
     extent::{Extent, SpatialExtent, TemporalExtent},
-    item::Item,
+    item::{Item, ITEM_TYPE},
     link::Link,
     object::Object,
     properties::Properties,
@@ -120,9 +121,9 @@ pub const STAC_VERSION: &str = "1.0.0";
 /// # Examples
 ///
 /// ```
-/// let catalog: stac::Catalog = stac::read("data/catalog.json").unwrap();
+/// let catalog = stac::read("data/catalog.json").unwrap();
 /// ```
-pub fn read<O: Object>(href: &str) -> Result<O, Error> {
+pub fn read(href: &str) -> Result<Object, Error> {
     let reader = Reader::new();
     reader.read(href, None)
 }


### PR DESCRIPTION
This improves our ergonomics by allowing access to common fields from either the main object types e.g. `Catalog` or from the enum wrapper `Object`. Also will let us guard certain fields, e.g. `links`, when we're working with trees.