### PR TITLE
Fix renderer type signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Doctesting for README.md
+
+### Fixed
+
+- Type signature for `BestPracticesRenderer::new` to `From<HRef>` (was `TryFrom<Href>`)
+
 ## [0.0.2] - 2022-02-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ println!("{}", object.id());
 
 Write STAC catalogs using the `BestPracticesRenderer`:
 
-```rust
+```rust,no_run
 use stac::{Stac, BestPracticesRenderer, Render, Writer, Write};
-let (stac, _) = Stac::read("data/catalog.json").unwrap();
-let renderer = BestPracticesRenderer::new("a/new/root/directory").unwrap();
+let (mut stac, _) = Stac::read("data/catalog.json").unwrap();
+let renderer = BestPracticesRenderer::new("a/new/root/directory");
 let writer = Writer::default();
 stac.write(&renderer, &writer).unwrap();
 ```

--- a/examples/copy.rs
+++ b/examples/copy.rs
@@ -15,6 +15,6 @@ fn main() {
     let outdir = &args[2];
 
     let (mut stac, _) = Stac::read(infile).unwrap();
-    let renderer = BestPracticesRenderer::new(outdir).unwrap();
+    let renderer = BestPracticesRenderer::new(outdir);
     stac.write(&renderer, &Writer::default()).unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,3 +256,17 @@ mod tests {
     }
     pub(crate) use roundtrip;
 }
+
+// From https://github.com/rust-lang/cargo/issues/383#issuecomment-720873790,
+// may they be forever blessed.
+#[cfg(doctest)]
+mod readme {
+    macro_rules! external_doc_test {
+        ($x:expr) => {
+            #[doc = $x]
+            extern "C" {}
+        };
+    }
+
+    external_doc_test!(include_str!("../README.md"));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@
 //!
 //! ## Writing
 //!
-//! Stac trees have a [write](Stac::write) method:
+//! Stac trees have a [write](Stac::write) method that renders and writes all in one:
 //!
 //! ```no_run
 //! use stac::{Stac, Render, BestPracticesRenderer, Writer};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@
 //! ```
 //! use stac::{Stac, Render, BestPracticesRenderer, Error};
 //! let (mut stac, _) = Stac::read("data/catalog.json").unwrap();
-//! let renderer = BestPracticesRenderer::new("the/root/directory").unwrap();
+//! let renderer = BestPracticesRenderer::new("the/root/directory");
 //! let objects = renderer.render(&mut stac).unwrap().collect::<Result<Vec<_>, Error>>().unwrap();
 //! assert_eq!(objects.len(), 6);
 //! assert_eq!(
@@ -126,7 +126,7 @@
 //! ```no_run
 //! use stac::{Stac, Render, BestPracticesRenderer, Writer};
 //! let (mut stac, _) = Stac::read("data/catalog.json").unwrap();
-//! let renderer = BestPracticesRenderer::new("the/root/directory").unwrap();
+//! let renderer = BestPracticesRenderer::new("the/root/directory");
 //! let writer = Writer::default();
 //! stac.write(&renderer, &writer).unwrap();
 //! ```

--- a/src/render.rs
+++ b/src/render.rs
@@ -7,7 +7,7 @@ use crate::{Error, Handle, Handles, Href, Link, Object, Read, Stac};
 /// ```
 /// use stac::{Stac, Render, BestPracticesRenderer, Error};
 /// let (mut stac, _) = Stac::read("data/catalog.json").unwrap();
-/// let renderer = BestPracticesRenderer::new("a/root/directory").unwrap();
+/// let renderer = BestPracticesRenderer::new("a/root/directory");
 /// let objects = renderer.render(&mut stac).unwrap().collect::<Result<Vec<_>, Error>>().unwrap();
 /// assert_eq!(objects.len(), 6);
 /// let root = &objects[0];
@@ -28,7 +28,7 @@ pub trait Render {
     ///
     /// ```
     /// # use stac::{Render, BestPracticesRenderer, Stac};
-    /// let renderer = BestPracticesRenderer::new("data").unwrap();
+    /// let renderer = BestPracticesRenderer::new("data");
     /// let (mut stac, handle) = Stac::read("data/catalog.json").unwrap();
     /// let objects = renderer
     ///     .render(&mut stac)
@@ -57,7 +57,7 @@ pub trait Render {
     ///
     /// ```
     /// # use stac::{Render, BestPracticesRenderer, Stac};
-    /// let renderer = BestPracticesRenderer::new("data").unwrap();
+    /// let renderer = BestPracticesRenderer::new("data");
     /// let (mut stac, handle) = Stac::read("data/catalog.json").unwrap();
     /// let objects = renderer.render_one(&mut stac, handle).unwrap();
     /// ```
@@ -113,7 +113,7 @@ pub trait Render {
     ///
     /// ```
     /// # use stac::{Render, BestPracticesRenderer, Stac};
-    /// let renderer = BestPracticesRenderer::new("a/root/directory").unwrap();
+    /// let renderer = BestPracticesRenderer::new("a/root/directory");
     /// let (mut stac, handle) = Stac::read("data/catalog.json").unwrap();
     /// let root = stac.take(handle).unwrap();
     /// let href = renderer.href(&mut stac, handle, &root).unwrap();
@@ -132,7 +132,7 @@ pub trait Render {
     ///
     /// ```
     /// # use stac::{BestPracticesRenderer, Render};
-    /// let renderer = BestPracticesRenderer::new("a/root/directory").unwrap();
+    /// let renderer = BestPracticesRenderer::new("a/root/directory");
     /// assert!(!renderer.is_absolute());
     /// ```
     fn is_absolute(&self) -> bool;
@@ -146,7 +146,7 @@ pub trait Render {
     ///
     /// ```
     /// # use stac::{BestPracticesRenderer, Link, Render};
-    /// let renderer = BestPracticesRenderer::new("a/root/directory").unwrap();
+    /// let renderer = BestPracticesRenderer::new("a/root/directory");
     /// let link = renderer.link(
     ///     &stac::read("data/catalog.json").unwrap(),
     ///     &stac::read("data/simple-item.json").unwrap(),
@@ -220,17 +220,16 @@ impl BestPracticesRenderer {
     /// # use stac::BestPracticesRenderer;
     /// let renderer = BestPracticesRenderer::new("data");
     /// ```
-    pub fn new<T, E>(root: T) -> Result<BestPracticesRenderer, Error>
+    pub fn new<T>(root: T) -> BestPracticesRenderer
     where
-        T: TryInto<Href, Error = E>,
-        Error: From<E>,
+        T: Into<Href>,
     {
-        let mut root = root.try_into()?;
+        let mut root = root.into();
         root.ensure_ends_in_slash();
-        Ok(BestPracticesRenderer {
+        BestPracticesRenderer {
             root,
             is_absolute: false,
-        })
+        }
     }
 
     fn file_name(&self, object: &Object) -> String {
@@ -288,7 +287,7 @@ mod tests {
 
     #[test]
     fn render_one() {
-        let renderer = BestPracticesRenderer::new("data").unwrap();
+        let renderer = BestPracticesRenderer::new("data");
         let (mut stac, handle) = Stac::with_root(Catalog::new("an-id")).unwrap();
         let object = renderer.render_one(&mut stac, handle).unwrap();
         assert_eq!(object.href.as_ref().unwrap().as_str(), "data/catalog.json");


### PR DESCRIPTION
## Description

Fixes the type signature for `BestPracticesRender`, because it was making us return an `Error` unnecessarily.

Sidecar:
- Test README.md doctests
- Small wording change in lib documentation

## Checklist

Delete any checklist items that do not apply (e.g. if your change is minor, it may not require documentation updates).

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
