### PR TITLE
Simplify render href

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Doctesting for README.md
 
+### Changed
+
+- Simplified `Render`'s href creation
+
 ### Fixed
 
 - Type signature for `BestPracticesRenderer::new` to `From<HRef>` (was `TryFrom<Href>`)


### PR DESCRIPTION
## Description

Simplifies how `Render` creates hrefs.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
