### PR TITLE
Make release its own workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}${{ matrix.flags }}
+      - name: Format
+        run: cargo fmt --verbose
       - name: Build
         run: cargo build --verbose ${{ matrix.flags }}
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,26 +29,8 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}${{ matrix.flags }}
       - name: Build
         run: cargo build --verbose ${{ matrix.flags }}
       - name: Run tests
         run: cargo test --verbose ${{ matrix.flags }}
-
-  release-dry-run:
-    needs: build
-    if: startsWith(github.head_ref, 'release/')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-      - name: Publish (dry run)
-        run: cargo publish --verbose --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release (dry run)
+
+on:
+  push:
+    branches:
+      - "release/**"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release-dry-run:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+      - name: Build
+        run: cargo build --verbose --release
+      - name: Run tests
+        run: cargo build --verbose --release
+      - name: Publish (dry run)
+        run: cargo publish --verbose --dry-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Simplified `Render`'s href creation
+- CI workflows
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Doctesting for README.md
+- `Href::rebase`
 
 ### Changed
 


### PR DESCRIPTION
## Description

Breaks off the release action into its own workflow that builds `--release`, tests `--release`, and publishes (dry run). Also improves the cache key to use the `matrix.flags`, and updates changelog for #36 because we forgot.

## Checklist

- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
