### PR TITLE
Refactor `Stac` API

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,29 @@
+name: Doc
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTDOCFLAGS: -Dwarnings
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+      - name: Doc
+        run: cargo doc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Doctesting for README.md
 - `Href::rebase`
+- `Object` and `HrefObject`
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Read STAC objects:
 
 ```rust
 let object = stac::read("data/catalog.json").unwrap();
-println!("{}", object.id());
 ```
 
 For more, see the [documentation](https://docs.rs/stac/latest/stac/).

--- a/src/href.rs
+++ b/src/href.rs
@@ -420,6 +420,12 @@ impl From<&str> for PathBufHref {
     }
 }
 
+impl From<&Href> for PathBufHref {
+    fn from(href: &Href) -> PathBufHref {
+        PathBufHref::new(href.as_str())
+    }
+}
+
 impl From<&String> for PathBufHref {
     fn from(s: &String) -> PathBufHref {
         PathBufHref::new(s)

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Object, PathBufHref};
+use crate::{Error, HrefObject, Object, PathBufHref};
 use serde_json::Value;
 use std::{fs::File, io::BufReader};
 use url::Url;
@@ -26,15 +26,14 @@ pub trait Read {
     /// let reader = Reader::default();
     /// let catalog = reader.read("data/catalog.json").unwrap();
     /// ```
-    fn read<T>(&self, href: T) -> Result<Object, Error>
+    fn read<T>(&self, href: T) -> Result<HrefObject, Error>
     where
         T: Into<PathBufHref>,
     {
         let href = href.into();
         let value = self.read_json(href.clone())?;
-        let mut object = Object::from_value(value)?;
-        object.href = Some(href.into());
-        Ok(object)
+        let object = Object::from_value(value)?;
+        Ok(HrefObject::new(object, href))
     }
 
     /// Reads JSON data from an href.
@@ -102,7 +101,7 @@ mod tests {
     fn read_fs() {
         let reader = Reader::default();
         let catalog = reader.read("data/catalog.json").unwrap();
-        assert_eq!(catalog.href.as_ref().unwrap().as_str(), "data/catalog.json",);
+        assert_eq!(catalog.href.as_str(), "data/catalog.json");
     }
 
     #[cfg(feature = "reqwest")]

--- a/src/stac.rs
+++ b/src/stac.rs
@@ -1,5 +1,5 @@
-use crate::{Error, Href, Item, Link, Object, PathBufHref, Read, Reader};
-use std::collections::{HashMap, HashSet, VecDeque};
+use crate::{Error, Href, Object, ObjectHrefTuple, PathBufHref, Read, Reader};
+use std::collections::{HashMap, HashSet};
 
 const ROOT_HANDLE: Handle = Handle(0);
 
@@ -18,85 +18,34 @@ pub struct Stac<R: Read> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Handle(pub usize);
 
-/// An iterator over a Stac's handles.
-#[derive(Debug)]
-pub struct Handles<'a, R: Read> {
-    handles: VecDeque<Handle>,
-    pub(crate) stac: &'a mut Stac<R>,
-}
-
-/// An iterator over a Stac's objects.
-#[derive(Debug)]
-pub struct Objects<'a, R: Read>(pub Handles<'a, R>);
-
-/// An iterator over a Stac's items.
-#[derive(Debug)]
-pub struct Items<'a, R: Read>(pub Objects<'a, R>);
-
 #[derive(Debug, Default)]
-pub(crate) struct Node {
-    pub(crate) object: Option<Object>,
-    pub(crate) children: HashSet<Handle>,
-    pub(crate) parent: Option<Handle>,
-    pub(crate) href: Option<Href>,
+struct Node {
+    object: Option<Object>,
+    children: HashSet<Handle>,
+    parent: Option<Handle>,
+    href: Option<Href>,
 }
 
 impl Stac<Reader> {
-    /// Creates a new Stac `rooted` at the provided object and configured to use
-    /// a [Reader].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use stac::Stac;
-    /// let catalog = stac::read("data/catalog.json").unwrap();
-    /// let (stac, handle) = Stac::with_root(catalog).unwrap();
-    /// ```
-    pub fn with_root<O>(object: O) -> Result<(Stac<Reader>, Handle), Error>
-    where
-        O: Into<Object>,
-    {
-        Stac::with_root_and_reader(object, Reader::default())
-    }
-
-    /// Creates a new `Stac` with the provided object and configured to use a
-    /// [Reader].
-    ///
-    /// If the object has a root link, that link will be used as the root node.
-    /// Otherwise, the provided object will be used as a root.
+    /// Creates a new `Stac` with the provided object and configured to use the
+    /// default [Reader].
     ///
     /// # Examples
     ///
     /// ```
     /// # use stac::{Stac, Catalog};
     /// let catalog = Catalog::new("an-id");
-    /// let stac = Stac::new(catalog);
+    /// let (stac, handle) = Stac::new(catalog).unwrap();
     /// ```
     pub fn new<O>(object: O) -> Result<(Stac<Reader>, Handle), Error>
     where
-        O: Into<Object>,
+        O: Into<ObjectHrefTuple>,
     {
-        let object = object.into();
-        if let Some(link) = object.links().iter().find(|link| link.is_root()) {
-            let mut href = Href::new(&link.href);
-            if let Some(base) = object.href.as_ref() {
-                href = base.join(href)?;
-                if &href == base {
-                    return Stac::with_root(object);
-                }
-            }
-            let (mut stac, _) = Stac::read(href)?;
-            let handle = stac.add_object(object)?;
-            Ok((stac, handle))
-        } else {
-            Stac::with_root(object)
-        }
+        Stac::new_with_reader(object, Reader::default())
     }
 
-    /// Reads a STAC object and returns a `Stac` and a handle to that object.
-    ///
-    /// If the object has a `root` link, that link will be used as the root
-    /// node. Otherwise, the read object will be used.
+    /// Reads a STAC object with the default [Reader] and returns a `Stac` and a
+    /// handle to that object.
     ///
     /// # Examples
     ///
@@ -108,403 +57,282 @@ impl Stac<Reader> {
     where
         T: Into<PathBufHref>,
     {
-        let object = crate::read(href)?;
-        Stac::new(object)
+        let reader = Reader::default();
+        let href_object = reader.read(href)?;
+        Stac::new_with_reader(href_object, reader)
     }
 }
 
 impl<R: Read> Stac<R> {
-    /// Creates a new Stac rooted at the provided object and with the provided
-    /// reader.
+    /// Creates a new Stac with the provided object and with the provided
+    /// [Read].
     ///
     /// # Examples
     ///
     /// ```
     /// # use stac::{Stac, Reader};
     /// let catalog = stac::read("data/catalog.json").unwrap();
-    /// let (stac, handle) = Stac::with_root_and_reader(catalog, Reader::default()).unwrap();
+    /// let (stac, handle) = Stac::new_with_reader(catalog, Reader::default()).unwrap();
     /// ```
-    pub fn with_root_and_reader<O>(object: O, reader: R) -> Result<(Stac<R>, Handle), Error>
+    pub fn new_with_reader<O>(object: O, reader: R) -> Result<(Stac<R>, Handle), Error>
     where
-        O: Into<Object>,
+        O: Into<ObjectHrefTuple>,
     {
-        let object = object.into();
-        let handle = ROOT_HANDLE;
-        let href = object.href.clone();
-        let mut hrefs = HashMap::new();
-        if let Some(href) = href.as_ref().cloned() {
-            let _ = hrefs.insert(href, handle);
+        let (object, href) = object.into();
+        if let Some(link) = object.root_link() {
+            let root_href = if let Some(href) = href.as_ref() {
+                href.join(&link.href)?
+            } else {
+                link.href.clone().into()
+            };
+            if !href
+                .as_ref()
+                .map(|href| *href == root_href)
+                .unwrap_or(false)
+            {
+                let root = reader.read(root_href)?;
+                let (mut stac, _) = Stac::rooted(root, reader)?;
+                let handle = stac.add_object(object)?;
+                return Ok((stac, handle));
+            }
         }
-        let node = Node {
-            object: None,
-            children: HashSet::new(),
-            parent: None,
-            href,
-        };
+        Stac::rooted((object, href), reader)
+    }
+
+    fn rooted<O>(object: O, reader: R) -> Result<(Stac<R>, Handle), Error>
+    where
+        O: Into<ObjectHrefTuple>,
+    {
+        let handle = ROOT_HANDLE;
+        let node = Node::default();
         let mut stac = Stac {
             reader,
             nodes: vec![node],
-            hrefs,
+            hrefs: HashMap::new(),
         };
-        stac.link_and_add(handle, object)?;
+        stac.set_object(handle, object)?;
         Ok((stac, handle))
     }
 
-    /// Returns a handle to the root object.
+    /// Returns the root handle of this [Stac].
     ///
     /// # Examples
     ///
     /// ```
     /// # use stac::Stac;
-    /// let (stac, _) = Stac::read("data/catalog.json").unwrap();
-    /// let handle = stac.root();
+    /// let (stac, root) = Stac::read("data/catalog.json").unwrap();
+    /// assert_eq!(stac.root(), root);
     /// ```
     pub fn root(&self) -> Handle {
         ROOT_HANDLE
     }
 
-    /// Returns a reference to an object in the stac.
+    /// Returns a reference to an object in this [Stac].
     ///
-    /// This method will read an unresolved node if need be.
+    /// This method will resolve the object using its [Href], which requires a mutable reference to the `Stac`.
     ///
     /// # Examples
     ///
     /// ```
     /// # use stac::Stac;
     /// let (mut stac, root) = Stac::read("data/catalog.json").unwrap();
-    /// let child_handle = stac.children(root).unwrap().next().unwrap();
-    /// let child = stac.get(child_handle).unwrap();
+    /// assert_eq!(stac.object(root).unwrap().id(), "examples");
     /// ```
-    pub fn get(&mut self, handle: Handle) -> Result<&Object, Error> {
+    pub fn object(&mut self, handle: Handle) -> Result<&Object, Error> {
         self.ensure_resolved(handle)?;
         Ok(self
             .node(handle)
             .object
             .as_ref()
-            .expect("node has been resolved"))
+            .expect("should be resolved"))
     }
 
-    /// Returns a mutable reference to an object in the stac.
-    ///
-    /// This method will read an unresolved node if need be.
+    /// Returns the parent handle of the node, if one is set.
     ///
     /// # Examples
     ///
     /// ```
     /// # use stac::Stac;
     /// let (mut stac, root) = Stac::read("data/catalog.json").unwrap();
-    /// let child_handle = stac.children(root).unwrap().next().unwrap();
-    /// let child = stac.get_mut(child_handle).unwrap();
+    /// assert_eq!(stac.parent(root), None);
+    /// let child = stac
+    ///     .find_child(root, |object| object.id() == "extensions-collection")
+    ///     .unwrap()
+    ///     .unwrap();
+    /// assert_eq!(stac.parent(child).unwrap(), root);
     /// ```
-    pub fn get_mut(&mut self, handle: Handle) -> Result<&mut Object, Error> {
-        self.ensure_resolved(handle)?;
-        Ok(self
-            .node_mut(handle)
-            .object
-            .as_mut()
-            .expect("node has been resolved"))
+    pub fn parent(&self, handle: Handle) -> Option<Handle> {
+        self.node(handle).parent
     }
 
-    /// Without modifying the tree structure, removes an object from a node.
-    ///
-    /// The node remains in the tree, and can will be re-read when needed again.
+    /// Adds an object to the [Stac].
     ///
     /// # Examples
     ///
     /// ```
-    /// # use stac::Stac;
-    /// let (mut stac, root) = Stac::read("data/catalog.json").unwrap();
-    /// let catalog = stac.take(root).unwrap();
-    /// assert_eq!(catalog.id(), "examples");
-    /// let catalog = stac.get(root).unwrap();
-    /// assert_eq!(catalog.id(), "examples");
+    /// # use stac::{Catalog, Stac};
+    /// let (mut stac, root) = Stac::new(Catalog::new("a-catalog")).unwrap();
+    /// let handle = stac.add_object(Catalog::new("unattached-catalog")).unwrap();
     /// ```
-    pub fn take(&mut self, handle: Handle) -> Result<Object, Error> {
-        self.ensure_resolved(handle)?;
-        Ok(self
-            .node_mut(handle)
-            .object
-            .take()
-            .expect("node is resolved"))
-    }
-
-    /// Sets the href for the given node.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use stac::Stac;
-    /// let (mut stac, root) = Stac::read("data/catalog.json").unwrap();
-    /// stac.set_href(root, "a/new/href").unwrap();
-    /// ```
-    pub fn set_href<T: Into<Href>>(&mut self, handle: Handle, href: T) -> Result<(), Error> {
-        self.nodes
-            .get_mut(handle.0)
-            .ok_or(Error::InvalidHandle(handle))?
-            .href = Some(href.into());
-        Ok(())
-    }
-
-    /// Gets the href for the given node.
-    pub fn href(&self, handle: Handle) -> Result<Option<&Href>, Error> {
-        Ok(self
-            .nodes
-            .get(handle.0)
-            .ok_or(Error::InvalidHandle(handle))?
-            .href
-            .as_ref())
-    }
-
-    /// Adds an object to this Stac.
-    pub fn add_object(&mut self, object: Object) -> Result<Handle, Error> {
-        let handle = if let Some(href) = object.href.as_ref().cloned() {
-            self.lookup_or_create(None, href)?
-        } else {
-            self.add_node(Node::default())
-        };
-        self.link_and_add(handle, object)?;
+    pub fn add_object<O>(&mut self, object: O) -> Result<Handle, Error>
+    where
+        O: Into<ObjectHrefTuple>,
+    {
+        let (object, href) = object.into();
+        let handle = href
+            .and_then(|href| self.hrefs.get(&href).cloned())
+            .unwrap_or_else(|| self.add_node());
+        self.set_object(handle, object)?;
         Ok(handle)
     }
 
-    /// Iterates over this stac's objects.
-    pub fn objects(&mut self) -> Objects<'_, R> {
-        Objects(self.handles())
-    }
-
-    /// Iterates over this stac's items.
-    pub fn items(&mut self) -> Items<'_, R> {
-        Items(self.objects())
-    }
-
-    /// Children
-    pub fn children(&self, handle: Handle) -> Result<impl Iterator<Item = Handle> + '_, Error> {
-        Ok(self
-            .nodes
-            .get(handle.0)
-            .ok_or(Error::InvalidHandle(handle))?
-            .children
-            .iter()
-            .cloned())
-    }
-
-    /// Iterate over this stac's handles.
-    pub fn handles(&mut self) -> Handles<'_, R> {
-        let mut handles = VecDeque::new();
-        handles.push_front(self.root());
-        Handles {
-            handles,
-            stac: self,
+    /// Finds a child object with a filter function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac::Stac;
+    /// let (mut stac, root) = Stac::read("data/catalog.json").unwrap();
+    /// assert_eq!(stac.parent(root), None);
+    /// let child = stac
+    ///     .find_child(root, |object| object.id() == "extensions-collection")
+    ///     .unwrap()
+    ///     .unwrap();
+    /// ```
+    pub fn find_child<F>(&mut self, parent: Handle, filter: F) -> Result<Option<Handle>, Error>
+    where
+        F: Fn(&Object) -> bool,
+    {
+        for child in self.node(parent).children.clone() {
+            let object = self.object(child)?;
+            if filter(object) {
+                return Ok(Some(child));
+            }
         }
+        Ok(None)
     }
 
-    /// Returns the parent of the provided node.
-    pub fn parent(&self, handle: Handle) -> Result<Option<Handle>, Error> {
-        Ok(self
-            .nodes
-            .get(handle.0)
-            .ok_or(Error::InvalidHandle(handle))?
-            .parent)
+    fn add_node(&mut self) -> Handle {
+        let handle = Handle(self.nodes.len());
+        self.nodes.push(Node::default());
+        handle
     }
 
-    pub(crate) fn ensure_resolved(&mut self, handle: Handle) -> Result<(), Error> {
-        if self
-            .nodes
-            .get(handle.0)
-            .ok_or(Error::InvalidHandle(handle))?
-            .object
-            .is_none()
-        {
+    fn ensure_resolved(&mut self, handle: Handle) -> Result<(), Error> {
+        if self.node(handle).object.is_none() {
             self.resolve(handle)?;
         }
         Ok(())
     }
 
     fn resolve(&mut self, handle: Handle) -> Result<(), Error> {
-        let object = if let Some(href) = self.node_mut(handle).href.clone() {
-            self.reader.read(href)?
-        } else {
-            return Err(Error::UnresolvableNode);
-        };
-        self.link_and_add(handle, object)
-    }
-
-    fn link_and_add(&mut self, handle: Handle, object: Object) -> Result<(), Error> {
-        self.link(handle, &object)?;
-        self.node_mut(handle).object = Some(object);
-        Ok(())
-    }
-
-    fn link(&mut self, handle: Handle, object: &Object) -> Result<(), Error> {
-        for link in object.links() {
-            if link.is_child() || link.is_item() {
-                self.add_child_link(handle, object.href.as_ref(), link)?;
-            } else if link.is_parent() {
-                self.add_parent_link(handle, object.href.as_ref(), link)?;
-            }
+        if let Some(href) = self.node(handle).href.as_ref() {
+            let href_object = self.reader.read(href)?;
+            self.set_object(handle, href_object)?;
         }
         Ok(())
     }
 
-    fn add_child_link(
-        &mut self,
-        parent: Handle,
-        base: Option<&Href>,
-        child: &Link,
-    ) -> Result<(), Error> {
-        let child = self.lookup_or_create(base, Href::new(&child.href))?;
-        self.add_child(parent, child)
-    }
-
-    fn add_parent_link(
-        &mut self,
-        child: Handle,
-        base: Option<&Href>,
-        parent: &Link,
-    ) -> Result<(), Error> {
-        let parent = self.lookup_or_create(base, Href::new(&parent.href))?;
-        self.add_child(parent, child)
-    }
-
-    fn add_child(&mut self, parent: Handle, child: Handle) -> Result<(), Error> {
-        let _ = self.node_mut(parent).children.insert(child);
-        let child = self.node_mut(child);
-        if child
-            .parent
-            .map(|previous| previous != parent)
-            .unwrap_or(false)
+    fn set_object<O>(&mut self, handle: Handle, object: O) -> Result<(), Error>
+    where
+        O: Into<ObjectHrefTuple>,
+    {
+        let (object, href) = object.into();
+        let mut children = HashSet::new();
+        for link in object
+            .links()
+            .iter()
+            .filter(|link| link.is_child() || link.is_item())
         {
-            unimplemented!()
+            let child_href = if let Some(href) = href.as_ref() {
+                href.join(&link.href)?
+            } else {
+                link.href.clone().into()
+            };
+            let child_handle = if let Some(child_handle) = self.hrefs.get(&child_href) {
+                *child_handle
+            } else {
+                let child_handle = self.add_node();
+                self.set_href(child_handle, child_href);
+                child_handle
+            };
+            self.node_mut(child_handle).parent = Some(handle);
+            let _ = children.insert(child_handle);
         }
-        child.parent = Some(parent);
+        if let Some(href) = href {
+            self.set_href(handle, href);
+        } else {
+            self.node_mut(handle).href = None;
+        }
+        let node = self.node_mut(handle);
+        node.object = Some(object);
+        node.children = children;
         Ok(())
     }
 
-    fn lookup_or_create(&mut self, base: Option<&Href>, mut href: Href) -> Result<Handle, Error> {
-        if let Some(base) = base {
-            href = base.join(href)?;
-        }
-        if let Some(handle) = self.hrefs.get(&href) {
-            Ok(*handle)
-        } else {
-            self.create_node(href)
-        }
+    fn set_href(&mut self, handle: Handle, href: Href) {
+        let _ = self.hrefs.insert(href.clone(), handle);
+        self.node_mut(handle).href = Some(href);
     }
 
-    fn create_node(&mut self, href: Href) -> Result<Handle, Error> {
-        let node = Node {
-            object: None,
-            children: HashSet::new(),
-            parent: None,
-            href: Some(href),
-        };
-        Ok(self.add_node(node))
-    }
-
-    fn add_node(&mut self, node: Node) -> Handle {
-        let handle = Handle(self.nodes.len());
-        if let Some(href) = node.href.as_ref().cloned() {
-            // TODO should we error if there's already a node w/ this href?
-            let _ = self.hrefs.insert(href, handle);
-        }
-        self.nodes.push(node);
-        handle
-    }
-
-    pub(crate) fn node(&self, handle: Handle) -> &Node {
+    fn node(&self, handle: Handle) -> &Node {
         &self.nodes[handle.0]
     }
 
-    pub(crate) fn node_mut(&mut self, handle: Handle) -> &mut Node {
+    fn node_mut(&mut self, handle: Handle) -> &mut Node {
         &mut self.nodes[handle.0]
-    }
-}
-
-impl<R: Read> Iterator for Handles<'_, R> {
-    type Item = Result<Handle, Error>;
-
-    fn next(&mut self) -> Option<Result<Handle, Error>> {
-        if let Some(handle) = self.handles.pop_front() {
-            match self.stac.ensure_resolved(handle) {
-                Ok(()) => {
-                    let node = self.stac.node(handle);
-                    self.handles.extend(&node.children);
-                    Some(Ok(handle))
-                }
-                Err(err) => Some(Err(err)),
-            }
-        } else {
-            None
-        }
-    }
-}
-
-impl<R: Read> Iterator for Objects<'_, R> {
-    type Item = Result<Object, Error>;
-
-    fn next(&mut self) -> Option<Result<Object, Error>> {
-        self.0.next().map(|result| {
-            result.map(|handle| {
-                self.0
-                    .stac
-                    .node_mut(handle)
-                    .object
-                    .take()
-                    .expect("should be resolved by the handles iterator")
-            })
-        })
-    }
-}
-
-impl<R: Read> Iterator for Items<'_, R> {
-    type Item = Result<Item, Error>;
-
-    fn next(&mut self) -> Option<Result<Item, Error>> {
-        if let Some(result) = self.0.next() {
-            match result {
-                Ok(object) => {
-                    if let Some(item) = object.into_item() {
-                        Some(Ok(item))
-                    } else {
-                        self.next()
-                    }
-                }
-                Err(err) => Some(Err(err)),
-            }
-        } else {
-            None
-        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::Stac;
+    use crate::{Catalog, HrefObject, Link};
+
+    #[test]
+    fn new() {
+        let (mut stac, handle) = Stac::new(Catalog::new("an-id")).unwrap();
+        assert_eq!(stac.object(handle).unwrap().id(), "an-id");
+    }
+
+    #[test]
+    fn link() {
+        let mut catalog = Catalog::new("an-id");
+        catalog
+            .links
+            .push(Link::new("./subcatalog/catalog.json", "child"));
+        let (mut stac, root_handle) =
+            Stac::new(HrefObject::new(catalog, "a/path/catalog.json")).unwrap();
+        let handle = stac
+            .add_object(HrefObject::new(
+                Catalog::new("child-catalog"),
+                "a/path/subcatalog/catalog.json",
+            ))
+            .unwrap();
+        assert_eq!(stac.parent(handle).unwrap(), root_handle);
+    }
+
+    #[test]
+    fn find_child() {
+        let (mut stac, root) = Stac::read("data/catalog.json").unwrap();
+        let child = stac
+            .find_child(root, |object| object.id() == "extensions-collection")
+            .unwrap()
+            .unwrap();
+        assert_eq!(stac.object(child).unwrap().id(), "extensions-collection");
+    }
 
     #[test]
     fn read() {
         let (mut stac, handle) = Stac::read("data/catalog.json").unwrap();
-        let catalog = stac.get(handle).unwrap();
+        let catalog = stac.object(handle).unwrap();
         assert_eq!(catalog.id(), "examples");
     }
 
     #[test]
     fn read_non_root() {
         let (mut stac, handle) = Stac::read("data/extensions-collection/collection.json").unwrap();
-        assert_eq!(stac.get(handle).unwrap().id(), "extensions-collection");
-        assert_eq!(stac.get(stac.root()).unwrap().id(), "examples");
-    }
-
-    #[test]
-    fn into_objects() {
-        let (mut stac, _) = Stac::read("data/catalog.json").unwrap();
-        let objects = stac.objects().collect::<Result<Vec<_>, _>>().unwrap();
-        assert_eq!(objects.len(), 6);
-    }
-
-    #[test]
-    fn into_items() {
-        let (mut stac, _) = Stac::read("data/catalog.json").unwrap();
-        let items = stac.items().collect::<Result<Vec<_>, _>>().unwrap();
-        assert_eq!(items.len(), 2);
+        assert_eq!(stac.object(handle).unwrap().id(), "extensions-collection");
+        assert_eq!(stac.object(stac.root()).unwrap().id(), "examples");
     }
 }


### PR DESCRIPTION
## Description

Refactors the `Stac` API to use a better `Object` and `HrefObject` classes. Also adds strict doc building to CI.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
