### PR TITLE
Add `Stac.add_child`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - `Href::rebase`
 - `Object` and `HrefObject`
 - Architecture diagram
+- `Stac.add_child`
 
 ### Changed
 


### PR DESCRIPTION
## Description

Adds `Stac.add_child`.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
