### PR TITLE
Walk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Architecture diagram
 - `Stac.add_child`
 - Benchmarks
+- `Walk`
+- `Stac::remove`
 
 ### Changed
 
 - Simplified `Render`'s href creation
 - CI workflows
+- `Stac::add_object` is now `add`
+- `Stac::add_child_handle` is now `connect`
+- `Stac::object` is now `get`
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["science", "data-structures"]
 [dependencies]
 chrono = "0.4"
 geojson = "0.22"
+indexmap = "1.8"
 reqwest = { version = "0.11", optional = true, features = ["json", "blocking"] }
 path-slash = "0.1"
 serde = { version = "1", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ mod stac;
 mod write;
 
 pub use {
-    crate::stac::{Handle, Stac},
+    crate::stac::{Handle, Stac, Walk},
     asset::Asset,
     catalog::{Catalog, CATALOG_TYPE},
     collection::{Collection, COLLECTION_TYPE},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@
 //! ```
 //!
 //! A `Stac` is a lazy cache, meaning that it doesn't read objects until needed, and keeps read objects in a cache keyed by their hrefs.
-//! Objects are read on-demand, e.g. via the [object](Stac::object) method:
+//! Objects are read on-demand, e.g. via the [get](Stac::get) method:
 //!
 //! ```
 //! # use stac::Stac;
@@ -99,7 +99,7 @@
 //!     .find_child(root, |object| object.id() == "extensions-collection")
 //!     .unwrap()
 //!     .unwrap();
-//! let child = stac.object(handle).unwrap();
+//! let child = stac.get(handle).unwrap();
 //! ```
 //!
 //! ## Layouts

--- a/src/stac.rs
+++ b/src/stac.rs
@@ -106,7 +106,7 @@ impl<R: Read> Stac<R> {
             {
                 let root = reader.read(root_href)?;
                 let (mut stac, _) = Stac::rooted(root, reader)?;
-                let handle = stac.add_object(object)?;
+                let handle = stac.add(object)?;
                 return Ok((stac, handle));
             }
         }
@@ -187,9 +187,9 @@ impl<R: Read> Stac<R> {
     /// ```
     /// # use stac::{Catalog, Stac};
     /// let (mut stac, root) = Stac::new(Catalog::new("a-catalog")).unwrap();
-    /// let handle = stac.add_object(Catalog::new("unattached-catalog")).unwrap();
+    /// let handle = stac.add(Catalog::new("unattached-catalog")).unwrap();
     /// ```
-    pub fn add_object<O>(&mut self, object: O) -> Result<Handle, Error>
+    pub fn add<O>(&mut self, object: O) -> Result<Handle, Error>
     where
         O: Into<ObjectHrefTuple>,
     {
@@ -214,7 +214,7 @@ impl<R: Read> Stac<R> {
     where
         O: Into<ObjectHrefTuple>,
     {
-        let child = self.add_object(object)?;
+        let child = self.add(object)?;
         self.connect(parent, child);
         Ok(child)
     }
@@ -421,7 +421,7 @@ mod tests {
         let (mut stac, root_handle) =
             Stac::new(HrefObject::new(catalog, "a/path/catalog.json")).unwrap();
         let handle = stac
-            .add_object(HrefObject::new(
+            .add(HrefObject::new(
                 Catalog::new("child-catalog"),
                 "a/path/subcatalog/catalog.json",
             ))

--- a/src/stac.rs
+++ b/src/stac.rs
@@ -301,8 +301,7 @@ impl<R: Read> Stac<R> {
         }
     }
 
-    /// Make sure that the given handle is resolved.
-    pub fn ensure_resolved(&mut self, handle: Handle) -> Result<(), Error> {
+    fn ensure_resolved(&mut self, handle: Handle) -> Result<(), Error> {
         if self.node(handle).object.is_none() {
             self.resolve(handle)?;
         }

--- a/src/stac.rs
+++ b/src/stac.rs
@@ -136,9 +136,9 @@ impl<R: Read> Stac<R> {
     /// ```
     /// # use stac::Stac;
     /// let (mut stac, root) = Stac::read("data/catalog.json").unwrap();
-    /// assert_eq!(stac.object(root).unwrap().id(), "examples");
+    /// assert_eq!(stac.get(root).unwrap().id(), "examples");
     /// ```
-    pub fn object(&mut self, handle: Handle) -> Result<&Object, Error> {
+    pub fn get(&mut self, handle: Handle) -> Result<&Object, Error> {
         self.ensure_resolved(handle)?;
         Ok(self
             .node(handle)
@@ -222,7 +222,7 @@ impl<R: Read> Stac<R> {
         F: Fn(&Object) -> bool,
     {
         for child in self.node(parent).children.clone() {
-            let object = self.object(child)?;
+            let object = self.get(child)?;
             if filter(object) {
                 return Ok(Some(child));
             }
@@ -312,7 +312,7 @@ mod tests {
     #[test]
     fn new() {
         let (mut stac, handle) = Stac::new(Catalog::new("an-id")).unwrap();
-        assert_eq!(stac.object(handle).unwrap().id(), "an-id");
+        assert_eq!(stac.get(handle).unwrap().id(), "an-id");
     }
 
     #[test]
@@ -347,20 +347,20 @@ mod tests {
             .find_child(root, |object| object.id() == "extensions-collection")
             .unwrap()
             .unwrap();
-        assert_eq!(stac.object(child).unwrap().id(), "extensions-collection");
+        assert_eq!(stac.get(child).unwrap().id(), "extensions-collection");
     }
 
     #[test]
     fn read() {
         let (mut stac, handle) = Stac::read("data/catalog.json").unwrap();
-        let catalog = stac.object(handle).unwrap();
+        let catalog = stac.get(handle).unwrap();
         assert_eq!(catalog.id(), "examples");
     }
 
     #[test]
     fn read_non_root() {
         let (mut stac, handle) = Stac::read("data/extensions-collection/collection.json").unwrap();
-        assert_eq!(stac.object(handle).unwrap().id(), "extensions-collection");
-        assert_eq!(stac.object(stac.root()).unwrap().id(), "examples");
+        assert_eq!(stac.get(handle).unwrap().id(), "extensions-collection");
+        assert_eq!(stac.get(stac.root()).unwrap().id(), "examples");
     }
 }

--- a/src/stac.rs
+++ b/src/stac.rs
@@ -214,9 +214,9 @@ impl<R: Read> Stac<R> {
     where
         O: Into<ObjectHrefTuple>,
     {
-        let child_handle = self.add_object(object)?;
-        self.add_child_handle(parent, child_handle);
-        Ok(child_handle)
+        let child = self.add_object(object)?;
+        self.connect(parent, child);
+        Ok(child)
     }
 
     /// Finds a child object with a filter function.
@@ -281,7 +281,7 @@ impl<R: Read> Stac<R> {
         (self.node_mut(handle).object.take(), href)
     }
 
-    fn add_child_handle(&mut self, parent: Handle, child: Handle) {
+    fn connect(&mut self, parent: Handle, child: Handle) {
         self.node_mut(child).parent = Some(parent);
         let _ = self.node_mut(parent).children.insert(child);
     }
@@ -332,14 +332,14 @@ impl<R: Read> Stac<R> {
             } else {
                 link.href.clone().into()
             };
-            let child_handle = if let Some(child_handle) = self.hrefs.get(&child_href) {
-                *child_handle
+            let child = if let Some(child) = self.hrefs.get(&child_href) {
+                *child
             } else {
-                let child_handle = self.add_node();
-                self.set_href(child_handle, child_href);
-                child_handle
+                let child = self.add_node();
+                self.set_href(child, child_href);
+                child
             };
-            self.add_child_handle(handle, child_handle);
+            self.connect(handle, child);
         }
         if let Some(href) = href {
             self.set_href(handle, href);


### PR DESCRIPTION
## Closes

- Closes #23 

## Description

Adds a walk structure (not trait) in `stac::stac`.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
