### PR TITLE
Read objects directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Top-level convenience functions for reading all three object types directly to structures
+- `Read::read_struct`
+- `Error::TypeMismatch`
+
 ## [0.0.3] - 2022-02-22
 
 ### Added

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,6 +51,15 @@ pub enum Error {
     #[error("serde_json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
 
+    /// Mismatch between expected and actual type fields.
+    #[error("type mismatch: expected={expected}, actual={actual}")]
+    TypeMismatch {
+        /// The expected type field.
+        expected: String,
+        /// The actual type field.
+        actual: String,
+    },
+
     /// Reeturned when the node cannot be resolved.
     #[error("the node is unresolved and does not have an href")]
     UnresolvableNode,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,6 +215,51 @@ where
     reader.read(href)
 }
 
+/// Reads a [Catalog] from an [Href].
+///
+/// # Examples
+///
+/// ```
+/// let catalog = stac::read_catalog("data/catalog.json").unwrap();
+/// ```
+pub fn read_catalog<H>(href: H) -> Result<Catalog, Error>
+where
+    H: Into<PathBufHref>,
+{
+    let reader = Reader::default();
+    reader.read_struct(href)
+}
+
+/// Reads a [Collection] from an [Href].
+///
+/// # Examples
+///
+/// ```
+/// let collection = stac::read_collection("data/collection.json").unwrap();
+/// ```
+pub fn read_collection<H>(href: H) -> Result<Collection, Error>
+where
+    H: Into<PathBufHref>,
+{
+    let reader = Reader::default();
+    reader.read_struct(href)
+}
+
+/// Reads an [Item] from an [Href].
+///
+/// # Examples
+///
+/// ```
+/// let item = stac::read_item("data/simple-item.json").unwrap();
+/// ```
+pub fn read_item<H>(href: H) -> Result<Item, Error>
+where
+    H: Into<PathBufHref>,
+{
+    let reader = Reader::default();
+    reader.read_struct(href)
+}
+
 #[cfg(test)]
 mod tests {
     use criterion as _;

--- a/src/object.rs
+++ b/src/object.rs
@@ -120,6 +120,14 @@ impl Object {
             _ => None,
         }
     }
+    /// Returns this object's type field.
+    pub fn r#type(&self) -> &str {
+        match &self {
+            Object::Item(item) => &item.r#type,
+            Object::Catalog(catalog) => &catalog.r#type,
+            Object::Collection(collection) => &collection.r#type,
+        }
+    }
 
     /// Returns a reference to this object's id.
     ///
@@ -291,5 +299,47 @@ impl From<Collection> for ObjectHrefTuple {
 impl From<Catalog> for ObjectHrefTuple {
     fn from(catalog: Catalog) -> ObjectHrefTuple {
         (Object::Catalog(catalog), None)
+    }
+}
+
+impl TryFrom<Object> for Catalog {
+    type Error = Error;
+
+    fn try_from(object: Object) -> Result<Catalog, Error> {
+        match object {
+            Object::Catalog(catalog) => Ok(catalog),
+            _ => Err(Error::TypeMismatch {
+                expected: CATALOG_TYPE.to_string(),
+                actual: object.r#type().to_string(),
+            }),
+        }
+    }
+}
+
+impl TryFrom<Object> for Collection {
+    type Error = Error;
+
+    fn try_from(object: Object) -> Result<Collection, Error> {
+        match object {
+            Object::Collection(collection) => Ok(collection),
+            _ => Err(Error::TypeMismatch {
+                expected: COLLECTION_TYPE.to_string(),
+                actual: object.r#type().to_string(),
+            }),
+        }
+    }
+}
+
+impl TryFrom<Object> for Item {
+    type Error = Error;
+
+    fn try_from(object: Object) -> Result<Item, Error> {
+        match object {
+            Object::Item(item) => Ok(item),
+            _ => Err(Error::TypeMismatch {
+                expected: ITEM_TYPE.to_string(),
+                actual: object.r#type().to_string(),
+            }),
+        }
     }
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -36,6 +36,27 @@ pub trait Read {
         Ok(HrefObject::new(object, href))
     }
 
+    /// Reads an object from an [Href](crate::Href) as the actual structure.
+    ///
+    /// # Examples
+    ///
+    /// [Reader] implements `Read`:
+    ///
+    /// ```
+    /// use stac::{Read, Reader, Catalog};
+    /// let reader = Reader::default();
+    /// let catalog: Catalog = reader.read_struct("data/catalog.json").unwrap();
+    /// ```
+    fn read_struct<H, O>(&self, href: H) -> Result<O, Error>
+    where
+        H: Into<PathBufHref>,
+        O: TryFrom<Object, Error = Error>,
+    {
+        let value = self.read_json(href.into())?;
+        let object = Object::from_value(value)?;
+        object.try_into()
+    }
+
     /// Reads JSON data from an href.
     ///
     /// # Examples


### PR DESCRIPTION
## Related to

- #22: As I'm building a book based on the PySTAC quickstart, I realized that I wanted top-level convenience functions for getting the structures.

## Description

Provides top-level convenience functions that allow quickly reading all three object types into their structs.

## Checklist

Delete any checklist items that do not apply (e.g. if your change is minor, it may not require documentation updates).

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
