### PR TITLE
Stac fixup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,15 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - `Href::file_name`
 - `Stac::collections`
 - More `Href` documentation
+- Options to customize the `Walk` strategy
+- `Stac::set_href`
 
 ## Changed
 
 - Made `Handle`s innards private
 - Generalized `Stac::find_child` to `Stac::find`
 - Made `PathBufHref::new` public
+- Cannot remove the root of a `Stac`
 
 ## Fixed
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,10 @@ use url::Url;
 /// Error enum for crate-specific errors.
 #[derive(Error, Debug)]
 pub enum Error {
+    /// Returned when you try to remove the root object from a [Stac](crate::Stac).
+    #[error("cannot remove root")]
+    CannotRemoveRoot,
+
     /// Returned when trying to write urls from the default writer.
     #[error("cannot write url: {0}")]
     CannotWriteUrl(Url),

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,10 +60,6 @@ pub enum Error {
         actual: String,
     },
 
-    /// Reeturned when the node cannot be resolved.
-    #[error("the node is unresolved and does not have an href")]
-    UnresolvableNode,
-
     /// [url::ParseError]
     #[error("url parse error: {0}")]
     Url(#[from] url::ParseError),

--- a/src/stac.rs
+++ b/src/stac.rs
@@ -4,10 +4,32 @@ use std::collections::{HashMap, VecDeque};
 
 const ROOT_HANDLE: Handle = Handle(0);
 
-/// An arena-based tree for accessing STAC catalogs.
+/// An arena-based tree for working with STAC catalogs.
 ///
-/// A `Stac` is generic over its `reader`, which allows `Stac`s to be configured
-/// to use custom readers if needed.
+/// A `Stac` is generic over [Read], which allows `Stac`s to be configured to
+/// use custom readers if needed. Many methods of `Stac` work with an
+/// [ObjectHrefTuple], which is a tuple an [Object] and an optional [Href].
+/// Since [Object] and [HrefObject](crate::HrefObject) both implement [Into] for
+/// [ObjectHrefTuple], this enables `Stac` methods to take objects both with and
+/// without hrefs.
+///
+/// A [Stac] uses [Handles](Handle) to reference objects in the tree. A `Handle`
+/// is tied to its `Stac`; using a `Handle` on a `Stac` other than the one that
+/// produced it is undefined behavior.
+///
+/// A `root` link is only used when creating a new `Stac`: if the initial object
+/// has a `root` link, it is used to set the root of the `Stac`. After that, all
+/// `root` links are ignored.
+///
+/// # Examples
+///
+/// ```
+/// use stac::{Stac, Catalog};
+/// let catalog = Catalog::new("root");
+/// let item = stac::read_item("data/simple-item.json").unwrap();
+/// let (mut stac, root) = Stac::new(catalog).unwrap();
+/// let child = stac.add_child(root, item).unwrap();
+/// ```
 #[derive(Debug)]
 pub struct Stac<R: Read> {
     reader: R,
@@ -16,11 +38,14 @@ pub struct Stac<R: Read> {
     hrefs: HashMap<Href, Handle>,
 }
 
-/// A pointer to a STAC object in a [Stac] tree.
+/// A pointer to an [Object] in a [Stac] tree.
+///
+/// Handles can only be used on the `Stac` that produced them. Using a `Handle`
+/// on a different `Stac` is undefined behavior.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Handle(usize);
 
-/// An iterator over a [Stac's](Stac) handles.
+/// An iterator over a [Stac's](Stac) [Handles](Handle).
 #[derive(Debug)]
 pub struct Walk<'a, R: Read, F, T>
 where
@@ -30,6 +55,14 @@ where
     stac: &'a mut Stac<R>,
     f: F,
     depth_first: bool,
+    strategy: WalkStrategy,
+}
+
+#[derive(Debug)]
+enum WalkStrategy {
+    SkipItems,
+    ItemsOnly,
+    All,
 }
 
 #[derive(Debug, Default)]
@@ -37,13 +70,15 @@ struct Node {
     object: Option<Object>,
     children: IndexSet<Handle>,
     parent: Option<Handle>,
-    root: Option<Handle>,
     href: Option<Href>,
+    is_from_item_link: bool,
 }
 
 impl Stac<Reader> {
-    /// Creates a new `Stac` with the provided object and configured to use the
-    /// default [Reader].
+    /// Creates a new `Stac` with the provided object and configured to use
+    /// [Reader].
+    ///
+    /// Returns a tuple of the `Stac` and the [Handle] to the object.
     ///
     /// # Examples
     ///
@@ -59,8 +94,9 @@ impl Stac<Reader> {
         Stac::new_with_reader(object, Reader::default())
     }
 
-    /// Reads a STAC object with the default [Reader] and returns a `Stac` and a
-    /// handle to that object.
+    /// Reads an [HrefObject](crate::HrefObject) with [Reader]
+    ///
+    /// Returns a tuple of the `Stac` and the [Handle] to that object.
     ///
     /// # Examples
     ///
@@ -79,8 +115,9 @@ impl Stac<Reader> {
 }
 
 impl<R: Read> Stac<R> {
-    /// Creates a new Stac with the provided object and with the provided
-    /// [Read].
+    /// Creates a new `Stac` from the [Object] and [Read].
+    ///
+    /// Returns a tuple of the `Stac` and the [Handle] to that object.
     ///
     /// # Examples
     ///
@@ -130,7 +167,7 @@ impl<R: Read> Stac<R> {
         Ok((stac, handle))
     }
 
-    /// Returns the root handle of this [Stac].
+    /// Returns the root [Handle] of this `Stac`.
     ///
     /// # Examples
     ///
@@ -143,9 +180,11 @@ impl<R: Read> Stac<R> {
         ROOT_HANDLE
     }
 
-    /// Returns a reference to an object in this [Stac].
+    /// Returns a reference to an [Object] in this `Stac`.
     ///
-    /// This method will resolve the object using its [Href], which requires a mutable reference to the `Stac`.
+    /// This method will resolve the object using its [Href], which requires a
+    /// mutable reference to the `Stac`. This will return an [Err] if there is
+    /// an error while reading the object.
     ///
     /// # Examples
     ///
@@ -163,7 +202,7 @@ impl<R: Read> Stac<R> {
             .expect("should be resolved"))
     }
 
-    /// Returns the parent handle of the node, if one is set.
+    /// Returns the parent [Handle] of this object, if one is set.
     ///
     /// # Examples
     ///
@@ -181,14 +220,32 @@ impl<R: Read> Stac<R> {
         self.node(handle).parent
     }
 
-    /// Adds an object to the [Stac].
+    /// Adds an [Object] to the [Stac].
+    ///
+    /// If this object has links, the links will be resolved and the object will
+    /// be linked into the tree.
     ///
     /// # Examples
+    ///
+    /// Adding an unattached object:
     ///
     /// ```
     /// # use stac::{Catalog, Stac};
     /// let (mut stac, root) = Stac::new(Catalog::new("a-catalog")).unwrap();
     /// let handle = stac.add(Catalog::new("unattached-catalog")).unwrap();
+    /// ```
+    ///
+    /// Adding an object that will be linked into the tree:
+    ///
+    /// ```
+    /// # use stac::{Catalog, HrefObject, Stac, Link};
+    /// # let (mut stac, root) = Stac::new(Catalog::new("a-catalog")).unwrap();
+    /// stac.set_href(root, "rootdir/catalog.json");
+    /// let mut catalog = Catalog::new("attached-catalog");
+    /// catalog.links.push(Link::parent("../catalog.json"));
+    /// let href_object = HrefObject::new(catalog, "rootdir/attached-catalog/catalog.json");
+    /// let child = stac.add(href_object).unwrap();
+    /// assert_eq!(stac.parent(child).unwrap(), root);
     /// ```
     pub fn add<O>(&mut self, object: O) -> Result<Handle, Error>
     where
@@ -196,20 +253,29 @@ impl<R: Read> Stac<R> {
     {
         let (object, href) = object.into();
         let handle = href
+            .as_ref()
             .and_then(|href| self.hrefs.get(&href).cloned())
             .unwrap_or_else(|| self.add_node());
-        self.set_object(handle, object)?;
+        self.set_object(handle, (object, href))?;
         Ok(handle)
     }
 
-    /// Adds an object to the [Stac] as a child of the provided handle.
+    /// Adds an [Object] to the [Stac] as a child of the provided handle.
+    ///
+    /// If there is a `parent` link on the `Object`, it will be ignored.
     ///
     /// # Examples
     ///
     /// ```
-    /// # use stac::{Item, Catalog, Stac};
+    /// # use stac::{Item, Catalog, Link, Stac};
     /// let (mut stac, root) = Stac::new(Catalog::new("a-catalog")).unwrap();
-    /// let handle = stac.add_child(root, Item::new("an-item")).unwrap();
+    /// let child = stac.add_child(root, Item::new("an-item")).unwrap();
+    /// assert_eq!(stac.parent(child).unwrap(), root);
+    ///
+    /// let mut second_item = Item::new("second-item");
+    /// second_item.links.push(Link::parent("some/other/parent.json"));
+    /// let child = stac.add_child(root, second_item).unwrap();
+    /// assert_eq!(stac.parent(child).unwrap(), root);
     /// ```
     pub fn add_child<O>(&mut self, parent: Handle, object: O) -> Result<Handle, Error>
     where
@@ -220,58 +286,27 @@ impl<R: Read> Stac<R> {
         Ok(child)
     }
 
-    /// Finds a child object with a filter function.
+    /// Removes an [Object] from the [Stac].
+    ///
+    /// Unlinks all parents and children. Note that this will leave the children
+    /// unattached.  Returns the [Object] and its [Href], if they exist (one of
+    /// them will). Returns an error if you try to remove the root object.
     ///
     /// # Examples
     ///
     /// ```
-    /// # use stac::Stac;
+    /// # use stac::{Stac, Error};
     /// let (mut stac, root) = Stac::read("data/catalog.json").unwrap();
-    /// assert_eq!(stac.parent(root), None);
-    /// let child = stac
-    ///     .find(root, |object| object.id() == "extensions-collection")
-    ///     .unwrap()
-    ///     .unwrap();
+    /// let child = stac.find(root, |o| o.id() == "extensions-collection").unwrap().unwrap();
+    /// let (child, href) = stac.remove(child).unwrap();
+    /// assert_eq!(child.unwrap().id(), "extensions-collection");
+    /// assert_eq!(href.unwrap().as_str(), "data/extensions-collection/collection.json");
+    /// assert!(matches!(stac.remove(root).unwrap_err(), Error::CannotRemoveRoot));
     /// ```
-    pub fn find<F>(&mut self, handle: Handle, filter: F) -> Option<Result<Handle, Error>>
-    where
-        F: Fn(&Object) -> bool,
-    {
-        self.walk(handle, |stac, handle| {
-            let object = stac.get(handle)?;
-            Ok((filter(object), handle))
-        }).filter_map(|result| match result {
-            Ok((keep, handle)) => if keep {
-                Some(Ok(handle))
-            } else {
-                None
-            },
-            Err(err) => Some(Err(err))
-        }).next()
-    }
-
-    /// Walks a [Stac].
-    pub fn walk<F, T>(&mut self, handle: Handle, f: F) -> Walk<'_, R, F, T>
-    where
-        F: Fn(&mut Stac<R>, Handle) -> Result<T, Error>,
-    {
-        let mut handles = VecDeque::new();
-        handles.push_front(handle);
-        Walk {
-            handles,
-            stac: self,
-            f,
-            depth_first: false,
+    pub fn remove(&mut self, handle: Handle) -> Result<(Option<Object>, Option<Href>), Error> {
+        if handle == self.root() {
+            return Err(Error::CannotRemoveRoot);
         }
-    }
-
-    /// Returns all child handles as a ref.
-    pub fn children(&self, handle: Handle) -> &IndexSet<Handle> {
-        &self.node(handle).children
-    }
-
-    /// Removes a node.
-    pub fn remove(&mut self, handle: Handle) -> (Option<Object>, Option<Href>) {
         let children = std::mem::take(&mut self.node_mut(handle).children);
         for child in children {
             self.disconnect(handle, child);
@@ -287,40 +322,140 @@ impl<R: Read> Stac<R> {
         };
         self.free_nodes.push(handle);
         let object = self.node_mut(handle).object.take();
-        (object, href)
+        Ok((object, href))
     }
 
-    /// Returns the href for a handle.
+    /// Returns the [Href] of an [Object].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac::{Stac, Catalog};
+    /// let (mut stac, root) = Stac::read("data/catalog.json").unwrap();
+    /// assert_eq!(stac.href(root).unwrap().as_str(), "data/catalog.json");
+    /// let catalog = stac.add(Catalog::new("unattached")).unwrap();
+    /// assert!(stac.href(catalog).is_none());
+    /// ```
     pub fn href(&self, handle: Handle) -> Option<&Href> {
         self.node(handle).href.as_ref()
     }
 
-    /// Returns the handles for all collections in this Stac.
-    /// 
+    /// Sets the [Href] of an [Object].
+    ///
+    /// If the `href` was already assigned to another object in the `Stac`, that
+    /// object's href will be cleared.
+    ///
     /// # Examples
-    /// 
+    ///
+    /// ```
+    /// # use stac::{Catalog, Stac};
+    /// let (mut stac, root) = Stac::new(Catalog::new("root")).unwrap();
+    /// assert!(stac.href(root).is_none());
+    /// stac.set_href(root, "path/to/the/root.catalog");
+    /// assert_eq!(stac.href(root).unwrap().as_str(), "path/to/the/root.catalog");
+    /// ```
+    ///
+    /// Clearing another object's href:
+    ///
+    /// ```
+    /// # use stac::{Catalog, Stac};
+    /// let (mut stac, root) = Stac::new(Catalog::new("root")).unwrap();
+    /// let child1 = stac.add_child(root, Catalog::new("child1")).unwrap();
+    /// stac.set_href(child1, "a/catalog.json");
+    /// assert_eq!(stac.href(child1).unwrap().as_str(), "a/catalog.json");
+    /// let child2 = stac.add_child(root, Catalog::new("child2")).unwrap();
+    /// stac.set_href(child2, "a/catalog.json");
+    /// assert_eq!(stac.href(child2).unwrap().as_str(), "a/catalog.json");
+    /// assert!(stac.href(child1).is_none());
+    /// ```
+    pub fn set_href<H>(&mut self, handle: Handle, href: H)
+    where
+        H: Into<Href>,
+    {
+        let href = href.into();
+        if let Some(other) = self.hrefs.insert(href.clone(), handle) {
+            let _ = self.node_mut(other).href.take();
+        }
+        if let Some(href) = self.node_mut(handle).href.replace(href) {
+            assert_eq!(
+                self.hrefs
+                    .remove(&href)
+                    .expect("there should be an entry in hrefs"),
+                handle
+            );
+        }
+    }
+
+    /// Returns a [Walk] iterator, which visits all objects in a [Stac] (by default).
+    ///
+    /// The `Walk` iterator holds a closure, which can be used to extract values
+    /// from the `Stac` or even modify it while walking.
+    ///
+    /// # Examples
+    ///
+    /// Collect all object ids:
+    ///
+    /// ```
+    /// # use stac::{Stac, Handle};
+    /// let (mut stac, root) = Stac::read("data/catalog.json").unwrap();
+    /// let ids = stac
+    ///     .walk(root, |stac, handle| {
+    ///         stac.get(handle).map(|object| String::from(object.id()))
+    ///     })
+    ///     .collect::<Result<Vec<_>, _>>()
+    ///     .unwrap();
+    /// assert_eq!(ids.len(), 6);
+    /// ```
+    pub fn walk<F, T>(&mut self, handle: Handle, f: F) -> Walk<'_, R, F, T>
+    where
+        F: Fn(&mut Stac<R>, Handle) -> Result<T, Error>,
+    {
+        let mut handles = VecDeque::new();
+        handles.push_front(handle);
+        Walk {
+            handles,
+            stac: self,
+            f,
+            depth_first: false,
+            strategy: WalkStrategy::All,
+        }
+    }
+
+    /// Finds an [Object] in the tree using a filter function.
+    ///
+    /// # Examples
+    ///
     /// ```
     /// # use stac::Stac;
-    /// let (mut stac, _) = Stac::read("data/catalog.json").unwrap();
-    /// let collections = stac.collections().unwrap();
-    /// assert_eq!(collections.len(), 3);
+    /// let (mut stac, root) = Stac::read("data/catalog.json").unwrap();
+    /// assert_eq!(stac.parent(root), None);
+    /// let child = stac
+    ///     .find(root, |object| object.id() == "extensions-collection")
+    ///     .unwrap()
+    ///     .unwrap();
+    /// assert_eq!(stac.get(child).unwrap().id(), "extensions-collection");
     /// ```
-    pub fn collections(&mut self) -> Result<Vec<Handle>, Error> {
-        self.walk(self.root(), |stac, handle| {
+    pub fn find<F>(&mut self, handle: Handle, filter: F) -> Result<Option<Handle>, Error>
+    where
+        F: Fn(&Object) -> bool,
+    {
+        self.walk(handle, |stac, handle| {
             let object = stac.get(handle)?;
-            Ok((handle, object.is_collection()))
-        }).filter_map(|result| 
-            match result {
-                Ok((handle, is_collection)) => if is_collection {
+            Ok((filter(object), handle))
+        })
+        .filter_map(|result| match result {
+            Ok((keep, handle)) => {
+                if keep {
                     Some(Ok(handle))
                 } else {
                     None
-                },
-                Err(err) => Some(Err(err))
+                }
             }
-        ).collect::<Result<Vec<_>, Error>>()
+            Err(err) => Some(Err(err)),
+        })
+        .next()
+        .transpose()
     }
-        
 
     fn connect(&mut self, parent: Handle, child: Handle) {
         self.node_mut(child).parent = Some(parent);
@@ -376,13 +511,13 @@ impl<R: Read> Stac<R> {
                 other
             };
             if link.is_child() || link.is_item() {
+                if link.is_item() {
+                    self.node_mut(other).is_from_item_link = true;
+                }
                 self.connect(handle, other);
             } else if link.is_parent() {
                 // TODO what to do if there is already a parent?
                 self.connect(other, handle);
-            } else if link.is_root() {
-                // TODO what to do if the root is different?
-                self.node_mut(handle).root = Some(other);
             }
         }
         if let Some(href) = href {
@@ -395,9 +530,12 @@ impl<R: Read> Stac<R> {
         Ok(())
     }
 
-    fn set_href(&mut self, handle: Handle, href: Href) {
-        let _ = self.hrefs.insert(href.clone(), handle);
-        self.node_mut(handle).href = Some(href);
+    fn is_item(&self, handle: Handle) -> bool {
+        if let Some(object) = self.node(handle).object.as_ref() {
+            object.is_item()
+        } else {
+            self.node(handle).is_from_item_link
+        }
     }
 
     fn node(&self, handle: Handle) -> &Node {
@@ -414,8 +552,65 @@ where
     F: Fn(&mut Stac<R>, Handle) -> Result<T, Error>,
 {
     /// Walk depth-first instead of breadth first.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac::Stac;
+    /// let (mut stac, root) = Stac::read("data/catalog.json").unwrap();
+    /// let ids = stac
+    ///     .walk(root, |stac, handle| {
+    ///         stac.get(handle).map(|object| String::from(object.id()))
+    ///     });
+    /// for result in ids.depth_first() {
+    ///     let id = result.unwrap();
+    ///     println!("{}", id);
+    /// }
+    /// ```
     pub fn depth_first(mut self) -> Walk<'a, R, F, T> {
         self.depth_first = true;
+        self
+    }
+
+    /// Skip items while walking the tree.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac::Stac;
+    /// let (mut stac, root) = Stac::read("data/catalog.json").unwrap();
+    /// let ids = stac
+    ///     .walk(root, |stac, handle| {
+    ///         stac.get(handle).map(|object| String::from(object.id()))
+    ///     })
+    ///     .skip_items()
+    ///     .collect::<Result<Vec<_>, _>>()
+    ///     .unwrap();
+    /// assert_eq!(ids.len(), 4);
+    /// ```
+    pub fn skip_items(mut self) -> Walk<'a, R, F, T> {
+        self.strategy = WalkStrategy::SkipItems;
+        self
+    }
+
+    /// Only stop at items when walking the tree.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac::Stac;
+    /// let (mut stac, root) = Stac::read("data/catalog.json").unwrap();
+    /// let ids = stac
+    ///     .walk(root, |stac, handle| {
+    ///         stac.get(handle).map(|object| String::from(object.id()))
+    ///     })
+    ///     .items_only()
+    ///     .collect::<Result<Vec<_>, _>>()
+    ///     .unwrap();
+    /// assert_eq!(ids.len(), 2);
+    /// ```
+    pub fn items_only(mut self) -> Walk<'a, R, F, T> {
+        self.strategy = WalkStrategy::ItemsOnly;
         self
     }
 }
@@ -427,21 +622,49 @@ where
     type Item = Result<T, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.handles.pop_front().map(|handle| {
-            self.stac
-                .ensure_resolved(handle)
-                .and_then(|()| (self.f)(self.stac, handle))
-                .map(|value| {
-                    if self.depth_first {
-                        for &child in self.stac.children(handle).iter().rev() {
-                            self.handles.push_front(child);
+        if let Some(handle) = self.handles.pop_front() {
+            if let Err(err) = self.stac.ensure_resolved(handle) {
+                self.handles.clear();
+                Some(Err(err))
+            } else {
+                match (self.f)(self.stac, handle) {
+                    Ok(value) => {
+                        let mut children = VecDeque::new();
+                        for &child in &self.stac.node(handle).children {
+                            if !(matches!(self.strategy, WalkStrategy::SkipItems)
+                                && self.stac.is_item(child))
+                            {
+                                if self.depth_first {
+                                    children.push_front(child);
+                                } else {
+                                    children.push_back(child);
+                                }
+                            }
                         }
-                    } else {
-                        self.handles.extend(self.stac.children(handle));
+                        if self.depth_first {
+                            for child in children {
+                                self.handles.push_front(child);
+                            }
+                        } else {
+                            self.handles.extend(children)
+                        }
+                        if !(matches!(self.strategy, WalkStrategy::ItemsOnly)
+                            && !self.stac.is_item(handle))
+                        {
+                            Some(Ok(value))
+                        } else {
+                            self.next()
+                        }
                     }
-                    value
-                })
-        })
+                    Err(err) => {
+                        self.handles.clear();
+                        Some(Err(err))
+                    }
+                }
+            }
+        } else {
+            None
+        }
     }
 }
 
@@ -552,11 +775,20 @@ mod tests {
 
     #[test]
     fn walk_remove() {
-        let (mut stac, handle) = Stac::read("data/catalog.json").unwrap();
+        let (mut stac, root) = Stac::read("data/catalog.json").unwrap();
         let count = stac
-            .walk(handle, |stac, handle| Ok(stac.remove(handle)))
+            .walk(root, |stac, handle| {
+                if handle != root {
+                    let _ = stac.remove(handle)?;
+                    Ok(())
+                } else {
+                    Ok(())
+                }
+            })
             .count();
-        assert_eq!(count, 1)
+        assert_eq!(count, 5);
+        assert!(stac.find(root, |o| o.is_collection()).unwrap().is_none());
+        assert!(stac.find(root, |o| o.is_item()).unwrap().is_none());
     }
 
     #[test]
@@ -568,6 +800,15 @@ mod tests {
         child.links.push(Link::child("./subcatalog/catlog.json"));
         child.links.push(Link::item("./42/42.json"));
         let handle = stac.add_child(root, child.clone()).unwrap();
-        assert_eq!(*stac.remove(handle).0.unwrap().as_catalog().unwrap(), child);
+        assert_eq!(
+            *stac
+                .remove(handle)
+                .unwrap()
+                .0
+                .unwrap()
+                .as_catalog()
+                .unwrap(),
+            child
+        );
     }
 }

--- a/src/stac.rs
+++ b/src/stac.rs
@@ -344,15 +344,12 @@ impl<R: Read> Stac<R> {
 
     fn ensure_resolved(&mut self, handle: Handle) -> Result<(), Error> {
         if self.node(handle).object.is_none() {
-            self.resolve(handle)?;
-        }
-        Ok(())
-    }
-
-    fn resolve(&mut self, handle: Handle) -> Result<(), Error> {
-        if let Some(href) = self.node(handle).href.as_ref() {
-            let href_object = self.reader.read(href)?;
-            self.set_object(handle, href_object)?;
+            if let Some(href) = self.node(handle).href.as_ref() {
+                let href_object = self.reader.read(href)?;
+                self.set_object(handle, href_object)?;
+            } else {
+                panic!("should not be able to get a node w/o an object or an href")
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
## Description

Cleans up the `Stac` interface and adds more docs and doctests.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
