### PR TITLE
Add crate-specific `Result`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
         with:
           toolchain: nightly
           override: true
+      - name: Clean
+        run: cargo clean
       - name: Test
         run: cargo test --verbose --no-fail-fast
         env:
@@ -79,8 +81,7 @@ jobs:
           RUSTDOCFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
       - id: coverage
         uses: actions-rs/grcov@v0.1
-      - name: Coveralls upload
-        uses: coverallsapp/github-action@master
+      - uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ${{ steps.coverage.outputs.report }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Options to customize the `Walk` strategy
 - `Stac::set_href`
 - Coverage
+- Crate-specific `Result`
 
 ## Changed
 

--- a/src/href.rs
+++ b/src/href.rs
@@ -1,4 +1,4 @@
-use crate::Error;
+use crate::{Error, Result};
 use path_slash::PathBufExt;
 use std::path::PathBuf;
 use url::Url;
@@ -111,7 +111,7 @@ impl Href {
     /// let item = base.join("./item/item.json").unwrap();
     /// assert_eq!(item.as_str(), "data/item/item.json");
     /// ```
-    pub fn join<T>(&self, href: T) -> Result<Href, Error>
+    pub fn join<T>(&self, href: T) -> Result<Href>
     where
         T: Into<Href>,
     {
@@ -236,7 +236,7 @@ impl Href {
     /// href.make_absolute().unwrap();
     /// let err = Href::new("not/a/real/path").make_absolute().unwrap_err();
     ///
-    pub fn make_absolute(&mut self) -> Result<(), Error> {
+    pub fn make_absolute(&mut self) -> Result<()> {
         if let Href::Path(path) = self {
             if let PathBufHref::Path(path) = PathBufHref::from(path.as_str()) {
                 let path = std::fs::canonicalize(path)?;
@@ -315,7 +315,7 @@ impl Href {
     /// item.rebase(&old_root_catalog, &new_root).unwrap();
     /// assert_eq!(item.as_str(), "a/new/base/item/item.json");
     /// ```
-    pub fn rebase(&mut self, from: &Href, to: &Href) -> Result<(), Error> {
+    pub fn rebase(&mut self, from: &Href, to: &Href) -> Result<()> {
         if let Href::Path(path) = self {
             if is_absolute(path) {
                 return Ok(());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,6 +200,9 @@ pub use {
 /// The default STAC version supported by this library.
 pub const STAC_VERSION: &str = "1.0.0";
 
+/// Custom [Result](std::result::Result) type for this crate.
+pub type Result<T> = std::result::Result<T, Error>;
+
 /// Reads a STAC object from an href.
 ///
 /// # Examples
@@ -207,7 +210,7 @@ pub const STAC_VERSION: &str = "1.0.0";
 /// ```
 /// let catalog = stac::read("data/catalog.json").unwrap();
 /// ```
-pub fn read<T>(href: T) -> Result<HrefObject, Error>
+pub fn read<T>(href: T) -> Result<HrefObject>
 where
     T: Into<PathBufHref>,
 {
@@ -222,7 +225,7 @@ where
 /// ```
 /// let catalog = stac::read_catalog("data/catalog.json").unwrap();
 /// ```
-pub fn read_catalog<H>(href: H) -> Result<Catalog, Error>
+pub fn read_catalog<H>(href: H) -> Result<Catalog>
 where
     H: Into<PathBufHref>,
 {
@@ -237,7 +240,7 @@ where
 /// ```
 /// let collection = stac::read_collection("data/collection.json").unwrap();
 /// ```
-pub fn read_collection<H>(href: H) -> Result<Collection, Error>
+pub fn read_collection<H>(href: H) -> Result<Collection>
 where
     H: Into<PathBufHref>,
 {
@@ -252,7 +255,7 @@ where
 /// ```
 /// let item = stac::read_item("data/simple-item.json").unwrap();
 /// ```
-pub fn read_item<H>(href: H) -> Result<Item, Error>
+pub fn read_item<H>(href: H) -> Result<Item>
 where
     H: Into<PathBufHref>,
 {

--- a/src/object.rs
+++ b/src/object.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Catalog, Collection, Error, Href, Item, Link, CATALOG_TYPE, COLLECTION_TYPE, ITEM_TYPE,
+    Catalog, Collection, Error, Href, Item, Link, Result, CATALOG_TYPE, COLLECTION_TYPE, ITEM_TYPE,
 };
 
 /// A type used to pass either an [Object] or an [HrefObject] into functions.
@@ -41,7 +41,7 @@ impl Object {
     /// let value: serde_json::Value = serde_json::from_reader(reader).unwrap();
     /// let object = Object::from_value(value).unwrap();
     /// ```
-    pub fn from_value(value: serde_json::Value) -> Result<Object, Error> {
+    pub fn from_value(value: serde_json::Value) -> Result<Object> {
         if let Some(type_) = value.get(TYPE_FIELD) {
             if let Some(type_) = type_.as_str() {
                 match type_ {
@@ -221,7 +221,7 @@ impl Object {
     /// let object = Object::from(Item::new("an-id"));
     /// let value = object.into_value().unwrap();
     /// ```
-    pub fn into_value(self) -> Result<serde_json::Value, Error> {
+    pub fn into_value(self) -> Result<serde_json::Value> {
         match self {
             Object::Item(item) => serde_json::to_value(item).map_err(Error::from),
             Object::Catalog(catalog) => serde_json::to_value(catalog).map_err(Error::from),
@@ -305,7 +305,7 @@ impl From<Catalog> for ObjectHrefTuple {
 impl TryFrom<Object> for Catalog {
     type Error = Error;
 
-    fn try_from(object: Object) -> Result<Catalog, Error> {
+    fn try_from(object: Object) -> Result<Catalog> {
         match object {
             Object::Catalog(catalog) => Ok(catalog),
             _ => Err(Error::TypeMismatch {
@@ -319,7 +319,7 @@ impl TryFrom<Object> for Catalog {
 impl TryFrom<Object> for Collection {
     type Error = Error;
 
-    fn try_from(object: Object) -> Result<Collection, Error> {
+    fn try_from(object: Object) -> Result<Collection> {
         match object {
             Object::Collection(collection) => Ok(collection),
             _ => Err(Error::TypeMismatch {
@@ -333,7 +333,7 @@ impl TryFrom<Object> for Collection {
 impl TryFrom<Object> for Item {
     type Error = Error;
 
-    fn try_from(object: Object) -> Result<Item, Error> {
+    fn try_from(object: Object) -> Result<Item> {
         match object {
             Object::Item(item) => Ok(item),
             _ => Err(Error::TypeMismatch {

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,4 +1,4 @@
-use crate::{Error, HrefObject, PathBufHref};
+use crate::{Error, HrefObject, PathBufHref, Result};
 use serde_json::Value;
 use std::{fs::File, io::BufWriter};
 
@@ -16,7 +16,7 @@ pub trait Write {
     /// let writer = Writer::default();
     /// writer.write(object).unwrap();
     /// ```
-    fn write(&self, object: HrefObject) -> Result<(), Error> {
+    fn write(&self, object: HrefObject) -> Result<()> {
         let value = object.object.into_value()?;
         self.write_value(value, object.href)
     }
@@ -34,7 +34,7 @@ pub trait Write {
     /// let writer = Writer::default();
     /// writer.write_value(data, "baz.json").unwrap();
     /// ```
-    fn write_value<T>(&self, value: Value, href: T) -> Result<(), Error>
+    fn write_value<T>(&self, value: Value, href: T) -> Result<()>
     where
         T: Into<PathBufHref>;
 }
@@ -47,7 +47,7 @@ pub struct Writer {
 }
 
 impl Write for Writer {
-    fn write_value<T>(&self, value: Value, href: T) -> Result<(), Error>
+    fn write_value<T>(&self, value: Value, href: T) -> Result<()>
     where
         T: Into<PathBufHref>,
     {


### PR DESCRIPTION
## Description

Add crate-specific `Result` type.

## Checklist

- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
