### PR TITLE
Add NextHref trait and Rebase

### DIFF
--- a/src/href.rs
+++ b/src/href.rs
@@ -354,6 +354,17 @@ impl Href {
         extract_path_filename(self.as_str()).0
     }
 
+    pub(crate) fn ensure_ends_in_slash(&mut self) {
+        match self {
+            Href::Url(url) => {
+                if let Ok(mut path_segments) = url.path_segments_mut() {
+                    let _ = path_segments.push("/");
+                }
+            }
+            Href::Path(path) => path.push('/'),
+        }
+    }
+
     fn into_string(self) -> String {
         match self {
             Href::Path(path) => path,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,7 @@ pub use {
     extent::{Extent, SpatialExtent, TemporalExtent},
     href::{Href, PathBufHref},
     item::{Item, ITEM_TYPE},
-    layout::Layout,
+    layout::{BestPractices, Layout, NextHref, Rebase},
     link::Link,
     object::{HrefObject, Object, ObjectHrefTuple},
     properties::Properties,

--- a/src/stac.rs
+++ b/src/stac.rs
@@ -1,5 +1,6 @@
 use crate::{
-    Error, Href, Layout, Link, Object, ObjectHrefTuple, PathBufHref, Read, Reader, Result, Write,
+    Error, Href, Layout, Link, NextHref, Object, ObjectHrefTuple, PathBufHref, Read, Reader,
+    Result, Write,
 };
 use indexmap::IndexSet;
 use std::collections::{HashMap, VecDeque};
@@ -436,6 +437,8 @@ impl<R: Read> Stac<R> {
 
     /// Gets the `next_href` for the object.
     ///
+    /// The `next_href` is used when rendering the [Stac] into an iterable of [HrefObjects](crate::HrefObject).
+    ///
     /// # Examples
     ///
     /// ```
@@ -450,6 +453,8 @@ impl<R: Read> Stac<R> {
     }
 
     /// Sets the `next_href` for the object.
+    ///
+    /// The `next_href` is used when rendering the [Stac] into an iterable of [HrefObjects](crate::HrefObject).
     ///
     /// # Examples
     ///
@@ -594,8 +599,9 @@ impl<R: Read> Stac<R> {
     /// let writer = Writer::default();
     /// stac.write(&layout, &writer).unwrap();
     /// ```
-    pub fn write<W>(self, layout: &Layout, writer: &W) -> Result<()>
+    pub fn write<N, W>(self, layout: &Layout<N>, writer: &W) -> Result<()>
     where
+        N: NextHref,
         W: Write,
     {
         for result in layout.render(self) {


### PR DESCRIPTION
## Closes

- Closes #52 
- Closes #33 

## Description

Adds the `NextHref` trait and the `Rebase` and `BestPractices` implementors.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
