### PR TITLE
fix: remove next_href

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - `Object::parent_link` and `Object::child_links`
 - `Stac::add_link` and `Stac::children`
 - `Layout`
-- `next_href` for `Stac` for rendering
 - Pull request template
 
 ## Changed

--- a/benches/layout.rs
+++ b/benches/layout.rs
@@ -14,7 +14,7 @@ fn layout_items(c: &mut Criterion) {
                 stac.add_child(root, Item::new(format!("item-{}", i)))
                     .unwrap();
             }
-            let layout = Layout::new("root");
+            let mut layout = Layout::new("root");
             b.iter(|| {
                 let _ = layout.layout(&mut stac).unwrap();
             })

--- a/examples/copy.rs
+++ b/examples/copy.rs
@@ -15,7 +15,7 @@ fn main() {
     let outdir = &args[2];
 
     let (stac, _) = Stac::read(infile).unwrap();
-    let layout = Layout::new(outdir);
+    let mut layout = Layout::new(outdir);
     let writer = Writer::default();
-    stac.write(&layout, &writer).unwrap();
+    stac.write(&mut layout, &writer).unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,18 +120,18 @@
 //! let (mut stac, root) = Stac::new(Catalog::new("root")).unwrap();
 //! let collection = stac.add_child(root, Collection::new("the-collection")).unwrap();
 //! let item = stac.add_child(collection, Item::new("an-item")).unwrap();
-//! let layout = Layout::new("my/stac/v0");
+//! let mut layout = Layout::new("my/stac/v0");
 //! layout.layout(&mut stac).unwrap();
 //! assert_eq!(
-//!     stac.next_href(root).unwrap().as_str(),
+//!     stac.href(root).unwrap().as_str(),
 //!     "my/stac/v0/catalog.json"
 //! );
 //! assert_eq!(
-//!     stac.next_href(collection).unwrap().as_str(),
+//!     stac.href(collection).unwrap().as_str(),
 //!     "my/stac/v0/the-collection/collection.json"
 //! );
 //! assert_eq!(
-//!     stac.next_href(item).unwrap().as_str(),
+//!     stac.href(item).unwrap().as_str(),
 //!     "my/stac/v0/the-collection/an-item/an-item.json"
 //! );
 //! ```
@@ -144,7 +144,7 @@
 //! ```no_run
 //! use stac::{Stac, Layout, Writer, Write};
 //! let (stac, _) = Stac::read("data/catalog.json").unwrap();
-//! let layout = Layout::new("my/stac/v0");
+//! let mut layout = Layout::new("my/stac/v0");
 //! let writer = Writer::default();
 //! for result in layout.render(stac) {
 //!     let href_object = result.unwrap();
@@ -230,7 +230,7 @@ pub use {
     extent::{Extent, SpatialExtent, TemporalExtent},
     href::{Href, PathBufHref},
     item::{Item, ITEM_TYPE},
-    layout::{BestPractices, Layout, NextHref, Rebase},
+    layout::{BestPractices, Layout, Rebase, Strategy},
     link::Link,
     object::{HrefObject, Object, ObjectHrefTuple},
     properties::Properties,


### PR DESCRIPTION
## Description

Removes `next_href` by doing more work on the children while laying out. Requires layout to become mutable while laying out.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
