### PR TITLE
Rename type_ to r#type on asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `Asset.type_` is now `Asset.r#type`
+
 ## [0.0.4] - 2022-03-09
 
 ### Added
@@ -85,7 +91,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 Initial release.
 
-[unreleased]: https://github.com/gadomski/stac-rs/compare/v0.0.4...HEAD
+[Unreleased]: https://github.com/gadomski/stac-rs/compare/v0.0.4...HEAD
 [0.0.4]: https://github.com/gadomski/stac-rs/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/gadomski/stac-rs/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/gadomski/stac-rs/compare/v0.0.1...v0.0.2

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    patch:
+      default:
+        informational: true
+
+github_checks:
+  annotations: true

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -22,9 +22,8 @@ pub struct Asset {
     /// [Media type](crate::media_type) of the asset.
     ///
     /// See the [common media types](https://github.com/radiantearth/stac-spec/blob/master/best-practices.md#common-media-types-in-stac) in the best practice doc for commonly used asset types.
-    #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub type_: Option<String>,
+    pub r#type: Option<String>,
 
     /// The semantic roles of the asset, similar to the use of rel in [Links](crate::Link).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -54,7 +53,7 @@ impl Asset {
             href: href.to_string(),
             title: None,
             description: None,
-            type_: None,
+            r#type: None,
             roles: None,
             additional_fields: Map::new(),
         }
@@ -71,7 +70,7 @@ mod tests {
         assert_eq!(asset.href, "an-href");
         assert!(asset.title.is_none());
         assert!(asset.description.is_none());
-        assert!(asset.type_.is_none());
+        assert!(asset.r#type.is_none());
         assert!(asset.roles.is_none());
     }
 


### PR DESCRIPTION
## Closes

- Closes #65 

## Description

Renames `type_` to `type` on asset to bring it into alignment with the rest of the structures.

## Checklist

- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
