### PR TITLE
Don't fail ci if cov error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,5 +84,5 @@ jobs:
       - uses: codecov/codecov-action@v2
         with:
           files: ./lcov.info
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
## Closes

- Closes #69 

## Related to

- Unblocks #68 
- Unblocks #66 

## Description

Set the "fail if coverage is bad" flag to false.

## Checklist

- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [ ] Changes are added to the CHANGELOG
