### PR TITLE
`read_json` takes a ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `Asset.type_` is now `Asset.r#type`
 - Rename `Read::read_struct` to `Read::read_object`
+- `Read::read_json` now takes a reference to a `PathBufHref`
 
 ## [0.0.4] - 2022-03-09
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -28,7 +28,7 @@ pub trait Read {
     /// ```
     fn read(&self, href: impl Into<PathBufHref>) -> Result<HrefObject> {
         let href = href.into();
-        let value = self.read_json(href.clone())?;
+        let value = self.read_json(&href)?;
         let object = Object::from_value(value)?;
         Ok(HrefObject::new(object, href))
     }
@@ -48,7 +48,8 @@ pub trait Read {
     where
         O: TryFrom<Object, Error = Error>,
     {
-        let value = self.read_json(href.into())?;
+        let href = href.into();
+        let value = self.read_json(&href)?;
         let object = Object::from_value(value)?;
         object.try_into()
     }
@@ -62,10 +63,11 @@ pub trait Read {
     /// ```
     /// use stac::{Read, Reader, Catalog, Href};
     /// let reader = Reader::default();
-    /// let value = reader.read_json("data/catalog.json").unwrap();
+    /// let href = Href::from("data/catalog.json");
+    /// let value = reader.read_json(&href.into()).unwrap();
     /// assert_eq!(value.get("type").unwrap().as_str().unwrap(), "Catalog");
     /// ```
-    fn read_json(&self, href: impl Into<PathBufHref>) -> Result<Value>;
+    fn read_json(&self, href: &PathBufHref) -> Result<Value>;
 }
 
 /// A basic reader for STAC objects.
@@ -86,8 +88,8 @@ pub trait Read {
 pub struct Reader();
 
 impl Read for Reader {
-    fn read_json(&self, href: impl Into<PathBufHref>) -> Result<Value> {
-        match href.into() {
+    fn read_json(&self, href: &PathBufHref) -> Result<Value> {
+        match href {
             PathBufHref::Path(path) => {
                 let file = File::open(path)?;
                 let buf_reader = BufReader::new(file);


### PR DESCRIPTION
## Description

`Read::read_json` was taking a generic `Into<PathBufHref>`, which was causing us to clone the href in the default read. By just taking a `&PathBufHref` instead, we eliminate the clone.

`read_json` is a relatively low-level function so I'm ok w/ it not being generic -- having to create the href yourself beforhand feels ok.

## Checklist

- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
