### PR TITLE
Make reqwest optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - `Asset.type_` is now `Asset.r#type`
 - Rename `Read::read_struct` to `Read::read_object`
 - `Read::read_json` now takes a reference to a `PathBufHref`
+- `reqwests` is now an optional feature
 
 ## [0.0.4] - 2022-03-09
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,6 @@ assert-json-diff = "2"
 criterion = "0.3"
 tempfile = "3"
 
-[features]
-default = ["reqwest"]
-
 [[bench]]
 name = "read"
 harness = false

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Crates.io](https://img.shields.io/crates/v/stac?style=for-the-badge)](https://crates.io/crates/stac)
 [![Codecov](https://img.shields.io/codecov/c/github/gadomski/stac-rs?style=for-the-badge)](https://app.codecov.io/gh/gadomski/stac-rs/)
 ![Crates.io](https://img.shields.io/crates/l/stac?style=for-the-badge)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=for-the-badge)](./CODE_OF_CONDUCT) 
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=for-the-badge)](./CODE_OF_CONDUCT)
 
 Rust implementation of the [SpatioTemporal Asset Catalog (STAC)](https://stacspec.org/) specification.
 
@@ -21,12 +21,12 @@ stac = "0.0.4"
 
 ### Features
 
-There is one opt-out feature:  `reqwest`.
-If you'd like to use the library without `reqwest`:
+There is one opt-in feature:  `reqwest`.
+If you'd like to use the library with `reqwest` for blocking remote reads:
 
 ```toml
 [dependencies]
-stac = { version = "0.0.4", features = []}
+stac = { version = "0.0.4", features = ["reqwest"]}
 ```
 
 If `reqwest` is not enabled, `Reader::read` will throw an error if you try to read from a url.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //! let catalog = Reader::default().read("data/catalog.json").unwrap();
 //! ```
 //!
-//! If the [reqwest](https://docs.rs/reqwest/latest/reqwest/) feature is enabled (it is enabled by default), it is used for network access:
+//! If the [reqwest](https://docs.rs/reqwest/latest/reqwest/) feature is enabled, it is used for network access:
 //!
 //! ```no_run
 //! # use stac::{Reader, Read};

--- a/src/read.rs
+++ b/src/read.rs
@@ -73,9 +73,9 @@ pub trait Read {
 /// A basic reader for STAC objects.
 ///
 /// This reader uses the standard library to read from the filesystem. If the
-/// `reqwest` feature is enabled (it is by default), blocking
+/// `reqwest` feature is enabled, blocking
 /// [reqwest](https://docs.rs/reqwest/latest/reqwest/) calls are used to read
-/// from urls. In the future, async calls may be supported, but are not yet.
+/// from urls.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
## Closes

- Closes #67

## Description

Make reqwests optional. We should nudge folks to use the (as of yet uncompleted) `stac-async` library to do actual, good IO.

## Checklist

- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
