### PR TITLE
Remove PathBufHref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,21 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `Href::to_slash`
+- `FromStr` for `Href`
+
 ### Changed
 
 - `Asset.type_` is now `Asset.r#type`
 - Rename `Read::read_struct` to `Read::read_object`
 - `Read::read_json` now takes a reference to a `PathBufHref`
 - `reqwests` is now an optional feature
+
+### Removed
+
+- `PathBufHref`
 
 ## [0.0.4] - 2022-03-09
 

--- a/src/href.rs
+++ b/src/href.rs
@@ -2,6 +2,7 @@ use crate::{Error, Result};
 use path_slash::{PathBufExt, PathExt};
 use std::{
     convert::Infallible,
+    fmt::{Display, Formatter},
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -412,6 +413,12 @@ impl FromStr for Href {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         Ok(Href::new(s))
+    }
+}
+
+impl Display for Href {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
     }
 }
 

--- a/src/href.rs
+++ b/src/href.rs
@@ -1,6 +1,6 @@
 use crate::{Error, Result};
-use path_slash::PathBufExt;
-use std::path::PathBuf;
+use path_slash::{PathBufExt, PathExt};
+use std::path::{Path, PathBuf};
 use url::Url;
 
 /// An href can be an absolute url, an absolute path, or a relative path.
@@ -11,18 +11,17 @@ use url::Url;
 /// provides a platform-independent way to store and manipulate the paths.
 ///
 /// `Href`s are always created from `/`-delimited strings. If you might be
-/// working with a `\` delimited string (e.g. on Windows), use [PathBufHref].
+/// working with a `\` delimited string (e.g. on Windows), use [Href::to_slash].
 ///
 /// ```
 /// use stac::Href;
+/// use std::path::PathBuf;
 /// let path_href = Href::new("a/path/to/an/item.json");
 /// let url_href = Href::new("http://example.com/item.json");
 ///
 /// #[cfg(target_os = "windows")]
 /// {
-///     use stac::PathBufHref;
-///     let path_buf_href = PathBufHref::new(r"a\path\to\an\item.json");
-///     let href = Href::from(path_buf_href);
+///     let href = Href::to_slash(r"a\path\to\an\item.json");
 ///     assert_eq!(href.as_str(), "a/path/to/an/item.json");
 /// }
 /// ```
@@ -33,37 +32,15 @@ pub enum Href {
 
     /// A path href, either relative or absolute.
     ///
-    /// This path will be `/`-delimited regardless of OS.
+    /// This path is always `/`-delimited.
     Path(String),
-}
-
-/// An href that uses [PathBuf] instead of a [String] for paths.
-///
-/// `PathBufHref` is used when actually reading or writing from hrefs, e.g. in
-/// the signature of [Read::read](crate::Read::read). `PathBufHref` can be
-/// converted from and to [Hrefs](Href), which uses
-/// [path-slash](https://github.com/rhysd/path-slash) to convert the `/`
-/// delimiters.
-///
-/// ```
-/// use stac::{Href, PathBufHref};
-/// let href = Href::new("data/catalog.json");
-/// let path_buf_href = PathBufHref::from(href);
-/// let href = Href::from(path_buf_href);
-/// ```
-#[derive(Debug, Clone)]
-pub enum PathBufHref {
-    /// A parsed url href.
-    Url(Url),
-
-    /// A filesystem path, stored as a [PathBuf].
-    Path(PathBuf),
 }
 
 impl Href {
     /// Creates an href.
     ///
-    /// Does not do any `\` conversion. If you need to handle possibly-`\`-delimited paths, use [PathBufHref].
+    /// Does not do any `\` conversion. If you need to handle
+    /// possibly-`\`-delimited paths, use [Href::to_slash].
     ///
     /// # Examples
     ///
@@ -86,6 +63,19 @@ impl Href {
             }
         } else {
             Href::Path(href)
+        }
+    }
+
+    /// Creates an href from a possibly `\`-delimited string.
+    ///
+    /// If the href is an url, no conversion is performed. Otherwise, the path
+    /// is converted from `\`-delimited to `/`-delimited.
+    pub fn to_slash(href: impl ToString) -> Href {
+        let href = Href::new(href);
+        if let Href::Path(path) = href {
+            Path::new(&path).into()
+        } else {
+            href
         }
     }
 
@@ -235,10 +225,8 @@ impl Href {
     ///
     pub fn make_absolute(&mut self) -> Result<()> {
         if let Href::Path(path) = self {
-            if let PathBufHref::Path(path) = PathBufHref::from(path.as_str()) {
-                let path = std::fs::canonicalize(path)?;
-                *self = PathBufHref::Path(path).into();
-            }
+            let path = PathBuf::from_slash(path).canonicalize()?;
+            *self = Href::Path(path.to_slash_lossy());
         }
         Ok(())
     }
@@ -370,68 +358,21 @@ impl Href {
     }
 }
 
-impl PathBufHref {
-    /// Creates a new href with system-specific delimiters.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use stac::{PathBufHref, Href};
-    ///
-    /// #[cfg(target_os = "windows")]
-    /// {
-    ///     use stac::PathBufHref;
-    ///     let path_buf_href = PathBufHref::new(r"a\path\to\an\item.json");
-    ///     let href = Href::from(path_buf_href);
-    ///     assert_eq!(href.as_str(), "a/path/to/an/item.json");
-    /// }
-    ///
-    /// #[cfg(not(target_os = "windows"))]
-    /// {
-    ///     use stac::PathBufHref;
-    ///     let path_buf_href = PathBufHref::new("a/path/to/an/item.json");
-    ///     let href = Href::from(path_buf_href);
-    ///     assert_eq!(href.as_str(), "a/path/to/an/item.json");
-    /// }
-    /// ```
-    pub fn new(href: impl ToString) -> PathBufHref {
-        Href::new(href).into()
-    }
-}
-
 impl From<Url> for Href {
     fn from(url: Url) -> Href {
         Href::Url(url)
     }
 }
 
-impl From<Href> for PathBufHref {
-    fn from(href: Href) -> PathBufHref {
-        match href {
-            Href::Url(url) => PathBufHref::Url(url),
-            Href::Path(path) => PathBufHref::Path(PathBuf::from_slash(path)),
-        }
-    }
-}
-
-impl From<PathBufHref> for Href {
-    fn from(href: PathBufHref) -> Href {
-        match href {
-            PathBufHref::Url(url) => Href::Url(url),
-            PathBufHref::Path(path) => Href::Path(path.to_slash_lossy()),
-        }
-    }
-}
-
-impl From<PathBuf> for PathBufHref {
-    fn from(path_buf: PathBuf) -> PathBufHref {
-        PathBufHref::Path(path_buf)
+impl From<&Path> for Href {
+    fn from(path: &Path) -> Href {
+        Href::Path(path.to_slash_lossy())
     }
 }
 
 impl From<PathBuf> for Href {
-    fn from(path_buf: PathBuf) -> Href {
-        PathBufHref::Path(path_buf).into()
+    fn from(path: PathBuf) -> Href {
+        Href::Path(path.to_slash_lossy())
     }
 }
 
@@ -459,30 +400,6 @@ impl From<Href> for String {
             Href::Url(url) => url.to_string(),
             Href::Path(path) => path,
         }
-    }
-}
-
-impl From<&str> for PathBufHref {
-    fn from(s: &str) -> PathBufHref {
-        PathBufHref::new(s)
-    }
-}
-
-impl From<&Href> for PathBufHref {
-    fn from(href: &Href) -> PathBufHref {
-        PathBufHref::new(href.as_str())
-    }
-}
-
-impl From<&String> for PathBufHref {
-    fn from(s: &String) -> PathBufHref {
-        PathBufHref::new(s)
-    }
-}
-
-impl From<String> for PathBufHref {
-    fn from(s: String) -> PathBufHref {
-        PathBufHref::new(s)
     }
 }
 

--- a/src/href.rs
+++ b/src/href.rs
@@ -1,6 +1,10 @@
 use crate::{Error, Result};
 use path_slash::{PathBufExt, PathExt};
-use std::path::{Path, PathBuf};
+use std::{
+    convert::Infallible,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 use url::Url;
 
 /// An href can be an absolute url, an absolute path, or a relative path.
@@ -400,6 +404,14 @@ impl From<Href> for String {
             Href::Url(url) => url.to_string(),
             Href::Path(path) => path,
         }
+    }
+}
+
+impl FromStr for Href {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Ok(Href::new(s))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@
 //!
 //! # Other features
 //!
-//! - The [Href] enum, and its sibling [PathBufHref], provide wrappers around remote and local hrefs and paths to ensure cross-platform compatibility.
+//! - The [Href] enum provides a wrapper around remote and local hrefs and paths to ensure cross-platform compatibility.
 //! - The source repository contains canonical examples copied the [stac-spec repository](https://github.com/radiantearth/stac-spec/tree/master/examples), and these examples are tested for round trip equality.
 //!   For example:
 //!
@@ -177,7 +177,7 @@ pub use {
     collection::{Collection, COLLECTION_TYPE},
     error::Error,
     extent::{Extent, SpatialExtent, TemporalExtent},
-    href::{Href, PathBufHref},
+    href::Href,
     item::{Item, ITEM_TYPE},
     layout::Layout,
     link::Link,
@@ -201,7 +201,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// ```
 /// let catalog = stac::read("data/catalog.json").unwrap();
 /// ```
-pub fn read(href: impl Into<PathBufHref>) -> Result<HrefObject> {
+pub fn read(href: impl Into<Href>) -> Result<HrefObject> {
     let reader = Reader::default();
     reader.read(href)
 }
@@ -211,11 +211,12 @@ pub fn read(href: impl Into<PathBufHref>) -> Result<HrefObject> {
 /// # Examples
 ///
 /// ```
-/// let catalog = stac::read_catalog("data/catalog.json").unwrap();
+/// use stac::Href;
+/// let catalog = stac::read_catalog(&Href::new("data/catalog.json")).unwrap();
 /// ```
-pub fn read_catalog(href: impl Into<PathBufHref>) -> Result<Catalog> {
+pub fn read_catalog(href: &Href) -> Result<Catalog> {
     let reader = Reader::default();
-    reader.read_object(href.into())
+    reader.read_object(href)
 }
 
 /// Reads a [Collection] from an [Href].
@@ -223,11 +224,12 @@ pub fn read_catalog(href: impl Into<PathBufHref>) -> Result<Catalog> {
 /// # Examples
 ///
 /// ```
-/// let collection = stac::read_collection("data/collection.json").unwrap();
+/// use stac::Href;
+/// let collection = stac::read_collection(&Href::new("data/collection.json")).unwrap();
 /// ```
-pub fn read_collection(href: impl Into<PathBufHref>) -> Result<Collection> {
+pub fn read_collection(href: &Href) -> Result<Collection> {
     let reader = Reader::default();
-    reader.read_object(href.into())
+    reader.read_object(href)
 }
 
 /// Reads an [Item] from an [Href].
@@ -235,11 +237,12 @@ pub fn read_collection(href: impl Into<PathBufHref>) -> Result<Collection> {
 /// # Examples
 ///
 /// ```
-/// let item = stac::read_item("data/simple-item.json").unwrap();
+/// use stac::Href;
+/// let item = stac::read_item(&Href::new("data/simple-item.json")).unwrap();
 /// ```
-pub fn read_item(href: impl Into<PathBufHref>) -> Result<Item> {
+pub fn read_item(href: &Href) -> Result<Item> {
     let reader = Reader::default();
-    reader.read_object(href.into())
+    reader.read_object(href)
 }
 
 #[cfg(test)]

--- a/src/stac/mod.rs
+++ b/src/stac/mod.rs
@@ -85,8 +85,8 @@ pub mod walk;
 pub use walk::{BorrowedWalk, OwnedWalk, Walk};
 
 use crate::{
-    layout::Strategy, Error, Href, Layout, Link, Object, ObjectHrefTuple, PathBufHref, Read,
-    Reader, Result, Write,
+    layout::Strategy, Error, Href, Layout, Link, Object, ObjectHrefTuple, Read, Reader, Result,
+    Write,
 };
 use indexmap::IndexSet;
 use std::collections::HashMap;
@@ -108,9 +108,9 @@ const ROOT_HANDLE: Handle = Handle(0);
 /// # Examples
 ///
 /// ```
-/// use stac::{Stac, Catalog};
+/// use stac::{Stac, Catalog, Href};
 /// let catalog = Catalog::new("root");
-/// let item = stac::read_item("data/simple-item.json").unwrap();
+/// let item = stac::read_item(&Href::new("data/simple-item.json")).unwrap();
 /// let (mut stac, root) = Stac::new(catalog).unwrap();
 /// let child = stac.add_child(root, item).unwrap();
 /// ```
@@ -174,7 +174,7 @@ impl Stac<Reader> {
     /// use stac::Stac;
     /// let (stac, handle) = Stac::read("data/catalog.json").unwrap();
     /// ```
-    pub fn read(href: impl Into<PathBufHref>) -> Result<(Stac<Reader>, Handle)> {
+    pub fn read(href: impl Into<Href>) -> Result<(Stac<Reader>, Handle)> {
         let reader = Reader::default();
         let href_object = reader.read(href)?;
         Stac::new_with_reader(href_object, reader)
@@ -581,7 +581,7 @@ impl<R: Read> Stac<R> {
 
     fn ensure_resolved(&mut self, handle: Handle) -> Result<()> {
         if self.node(handle).object.is_none() {
-            if let Some(href) = self.node(handle).href.as_ref() {
+            if let Some(href) = self.node_mut(handle).href.take() {
                 let href_object = self.reader.read(href)?;
                 self.set_object(handle, href_object)?;
             } else {


### PR DESCRIPTION
## Closes

- Closes #75 

## Description

Remove `PathBufHref` and impl `FromStr` for `Href`. It was too complex for what it needed to be. The `Href::to_slash` method is the new cross-platform href entrypoint.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
