### PR TITLE
Change grcov prefix dir

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -4,7 +4,7 @@ llvm: true
 filter: covered
 output-type: lcov
 output-path: ./lcov.info
-prefix-dir: /home/user/build/
+prefix-dir: /home/user/build/src
 ignore:
   - "/*"
   - "../*"


### PR DESCRIPTION
## Description

Change grcov prefix dir to make the sunburst better.

## Checklist

- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`

