### PR TITLE
Fix example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ There is one example at [examples/copy.rs](./examples/copy.rs) that demonstrates
 To run it from the command line:
 
 ```shell
-cargo run --examples copy data/catalog.json tmp
+cargo run --example copy data/catalog.json tmp
 ```
 
 ## Incubator


### PR DESCRIPTION
## Closes

None

## Related to

- Found by @pkopparla in #22 

## Description

Small README fix for how to run the examples.

## Checklist

- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`

