### PR TITLE
feat: warn on missing code examples

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,7 @@
     unused_qualifications,
     unused_results
 )]
+#![warn(rustdoc::missing_doc_code_examples)]
 
 mod asset;
 mod catalog;


### PR DESCRIPTION
## Related to

- Makes it easier to find functions that need documentation for #22 

## Description

This is only supported on nightly, so is silent for default builds. https://doc.rust-lang.org/rustdoc/lints.html#missing_doc_code_examples

cc @pkopparla

## Checklist

- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [ ] Changes are added to the CHANGELOG
