### PR TITLE
Add assets accessor for object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - `FromStr` for `Href`
 - `Object::self_link`
 - Warnings for missing code examples (only works on nightly)
+- `Object::assets`
 
 ### Changed
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,9 @@ coverage:
     patch:
       default:
         informational: true
+    project:
+      default:
+        threshold: 1%
 
 github_checks:
   annotations: true

--- a/src/object.rs
+++ b/src/object.rs
@@ -1,5 +1,8 @@
+use std::collections::HashMap;
+
 use crate::{
-    Catalog, Collection, Error, Href, Item, Link, Result, CATALOG_TYPE, COLLECTION_TYPE, ITEM_TYPE,
+    Asset, Catalog, Collection, Error, Href, Item, Link, Result, CATALOG_TYPE, COLLECTION_TYPE,
+    ITEM_TYPE,
 };
 
 /// A type used to pass either an [Object] or an [HrefObject] into functions.
@@ -167,6 +170,22 @@ impl Object {
                 .and_then(|value| value.as_str()),
             Object::Catalog(catalog) => catalog.title.as_deref(),
             Object::Collection(collection) => collection.title.as_deref(),
+        }
+    }
+
+    /// Returns a reference to this object's assets.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let href_object = stac::read("data/simple-item.json").unwrap();
+    /// assert!(href_object.object.assets().is_some());
+    /// ```
+    pub fn assets(&self) -> Option<&HashMap<String, Asset>> {
+        match &self {
+            Object::Item(item) => Some(&item.assets),
+            Object::Collection(collection) => collection.assets.as_ref(),
+            Object::Catalog(_) => None,
         }
     }
 


### PR DESCRIPTION
## Description

Add assets accessor for object.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
