### PR TITLE
Release v0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.0.5] - 2022-11-12
+
 ### Added
 
 - `Href` trait
@@ -17,8 +19,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `Asset.type_` is now `Asset.r#type`
 - `reqwest` is now an optional feature
-
-### Fixed
 
 ### Removed
 
@@ -111,7 +111,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 Initial release.
 
-[Unreleased]: https://github.com/gadomski/stac-rs/compare/v0.0.4...HEAD
+[Unreleased]: https://github.com/gadomski/stac-rs/compare/v0.0.5...HEAD
+[0.0.5]: https://github.com/gadomski/stac-rs/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/gadomski/stac-rs/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/gadomski/stac-rs/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/gadomski/stac-rs/compare/v0.0.1...v0.0.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stac"
-version = "0.0.5-alpha.1"
+version = "0.0.5"
 authors = ["Pete Gadomski <pete.gadomski@gmail.com>"]
 edition = "2021"
 description = "Rust library for the SpatioTemporal Asset Catalog (STAC) specification"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To use the library in your project:
 
 ```toml
 [dependencies]
-stac = "0.0.4"
+stac = "0.0.5"
 ```
 
 ### Features
@@ -26,7 +26,7 @@ If you'd like to use the library with `reqwest` for blocking remote reads:
 
 ```toml
 [dependencies]
-stac = { version = "0.0.4", features = ["reqwest"]}
+stac = { version = "0.0.5", features = ["reqwest"]}
 ```
 
 If `reqwest` is not enabled, `Reader::read` will throw an error if you try to read from a url.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,5 +17,4 @@ These should be taken from the CHANGELOG, but any leading `### Heading` should b
 - [ ] Version is updated in README.md examples
 - [ ] CHANGELOG is updated w/ correct header and correct links
 - [ ] CHANGELOG content is audited for correctness and clarity
-- [ ] (after merge, if necessary) Run `cargo install cargo-release`
 - [ ] (after merge) Run `cargo release`


### PR DESCRIPTION
# Version number

v0.0.5

## Release notes

```text
Added:

- `Href` trait
- `Value`

Changed:

- `Asset.type_` is now `Asset.r#type`
- `reqwest` is now an optional feature

Removed:

- `PathBufHref`
- `Href::into_string`
- `Stac`
- `Layout`
- `Reader`
- `Writer`
- `Object`
- `Href` struct
- benchmarks
```

## Checklist

- [x] Branch is formatted `release/vX.Y.Z`
- [x] Version is updated in Cargo.toml
- [x] Version is updated in README.md examples
- [x] CHANGELOG is updated w/ correct header and correct links
- [x] CHANGELOG content is audited for correctness and clarity
- [ ] (after merge) Run `cargo release`
