### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.0] - 2022-11-30
+
 ### Added
 
 - `stac::read_json`
@@ -129,7 +131,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 Initial release.
 
-[Unreleased]: https://github.com/gadomski/stac-rs/compare/v0.0.5...HEAD
+[Unreleased]: https://github.com/gadomski/stac-rs/compare/v0.1.0...main
+[0.1.0]: https://github.com/gadomski/stac-rs/compare/v0.0.5...v0.1.0
 [0.0.5]: https://github.com/gadomski/stac-rs/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/gadomski/stac-rs/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/gadomski/stac-rs/compare/v0.0.2...v0.0.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stac"
-version = "0.0.5"
+version = "0.1.0"
 authors = ["Pete Gadomski <pete.gadomski@gmail.com>"]
 edition = "2021"
 description = "Rust library for the SpatioTemporal Asset Catalog (STAC) specification"
@@ -21,7 +21,6 @@ url = "2"
 
 [dev-dependencies]
 assert-json-diff = "2"
-
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To use the library in your project:
 
 ```toml
 [dependencies]
-stac = "0.0.5"
+stac = "0.1.0"
 ```
 
 ### Features
@@ -25,7 +25,7 @@ If you'd like to use the library with `reqwest` for blocking remote reads:
 
 ```toml
 [dependencies]
-stac = { version = "0.0.5", features = ["reqwest"]}
+stac = { version = "0.1.0", features = ["reqwest"]}
 ```
 
 If `reqwest` is not enabled, `stac::read` will throw an error if you try to read from a url.


### PR DESCRIPTION
# Version number

0.1.0

## Release notes

```text
Added:

- `stac::read_json`

Changed:

- Module layout

Removed:

- `Item::set_collection` and `Item::collection_link`
- CI coverage
- `stac::read_from_url` and `stac::read_from_path`

Fixed:

- Documentation examples
```

## Checklist

- [x] Branch is formatted `release/vX.Y.Z`
- [x] Version is updated in Cargo.toml
- [x] Version is updated in README.md examples
- [x] CHANGELOG is updated w/ correct header and correct links
- [x] CHANGELOG content is audited for correctness and clarity
- [ ] (after merge) Run `cargo release`
