### PR TITLE
Deprecate Error::TypeMismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Deprecated
+
+- `Error::TypeMismatch` ([#93](https://github.com/gadomski/stac-rs/pull/93))
+
 ## [0.1.0] - 2022-11-30
 
 ### Added

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,6 +57,7 @@ pub enum Error {
 
     /// Mismatch between expected and actual type fields.
     #[error("type mismatch: expected={expected}, actual={actual}")]
+    #[deprecated(since = "0.1.1", note = "use Error::IncorrecType instead")]
     TypeMismatch {
         /// The expected type field.
         expected: String,


### PR DESCRIPTION
## Description

Use Error::IncorrectType instead

## Checklist

- [x] Unit tests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
