### PR TITLE
Add links trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `Links` trait ([#95](https://github.com/gadomski/stac-rs/pull/95))
+
 ## [0.1.1] - 2022-12-01
 
 ### Deprecated

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -1,4 +1,4 @@
-use crate::{Href, Link, STAC_VERSION};
+use crate::{Href, Link, Links, STAC_VERSION};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
@@ -86,6 +86,12 @@ impl Href for Catalog {
 
     fn set_href(&mut self, href: impl ToString) {
         self.href = Some(href.to_string())
+    }
+}
+
+impl Links for Catalog {
+    fn links(&self) -> &[Link] {
+        &self.links
     }
 }
 

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -1,4 +1,4 @@
-use crate::{Asset, Href, Link, STAC_VERSION};
+use crate::{Asset, Href, Link, Links, STAC_VERSION};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::collections::HashMap;
@@ -183,6 +183,12 @@ impl Href for Collection {
 
     fn set_href(&mut self, href: impl ToString) {
         self.href = Some(href.to_string())
+    }
+}
+
+impl Links for Collection {
+    fn links(&self) -> &[Link] {
+        &self.links
     }
 }
 

--- a/src/item.rs
+++ b/src/item.rs
@@ -1,4 +1,4 @@
-use crate::{Asset, Href, Link, STAC_VERSION};
+use crate::{Asset, Href, Link, Links, STAC_VERSION};
 use chrono::Utc;
 use geojson::Geometry;
 use serde::{Deserialize, Serialize};
@@ -139,6 +139,12 @@ impl Href for Item {
 
     fn set_href(&mut self, href: impl ToString) {
         self.href = Some(href.to_string())
+    }
+}
+
+impl Links for Item {
+    fn links(&self) -> &[Link] {
+        &self.links
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ pub use {
     href::Href,
     io::{read, read_json},
     item::{Item, Properties, ITEM_TYPE},
-    link::Link,
+    link::{Link, Links},
     value::Value,
 };
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,5 +1,6 @@
 use crate::{
-    Catalog, Collection, Error, Href, Item, Result, CATALOG_TYPE, COLLECTION_TYPE, ITEM_TYPE,
+    Catalog, Collection, Error, Href, Item, Link, Links, Result, CATALOG_TYPE, COLLECTION_TYPE,
+    ITEM_TYPE,
 };
 use std::convert::TryFrom;
 
@@ -211,6 +212,17 @@ impl Href for Value {
             Catalog(catalog) => catalog.set_href(href),
             Collection(collection) => collection.set_href(href),
             Item(item) => item.set_href(href),
+        }
+    }
+}
+
+impl Links for Value {
+    fn links(&self) -> &[Link] {
+        use Value::*;
+        match self {
+            Catalog(catalog) => catalog.links(),
+            Collection(collection) => collection.links(),
+            Item(item) => item.links(),
         }
     }
 }


### PR DESCRIPTION
## Description

Add a links trait that can be used for quick access to links of various rel types.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
