### PR TITLE
Add description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `description` to `Catalog::new` and `Collection::new` ([#102](https://github.com/gadomski/stac-rs/pull/102))
+
 ## [0.1.2] - 2022-12-08
 
 ### Added

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -61,17 +61,18 @@ impl Catalog {
     ///
     /// ```
     /// use stac::Catalog;
-    /// let catalog = Catalog::new("an-id");
+    /// let catalog = Catalog::new("an-id", "a description");
     /// assert_eq!(catalog.id, "an-id");
+    /// assert_eq!(catalog.description, "a description");
     /// ```
-    pub fn new(id: impl ToString) -> Catalog {
+    pub fn new(id: impl ToString, description: impl ToString) -> Catalog {
         Catalog {
             r#type: CATALOG_TYPE.to_string(),
             version: STAC_VERSION.to_string(),
             extensions: None,
             id: id.to_string(),
             title: None,
-            description: String::new(),
+            description: description.to_string(),
             links: Vec::new(),
             additional_fields: Map::new(),
             href: None,
@@ -105,9 +106,9 @@ mod tests {
 
     #[test]
     fn new() {
-        let catalog = Catalog::new("an-id");
+        let catalog = Catalog::new("an-id", "a description");
         assert!(catalog.title.is_none());
-        assert_eq!(catalog.description, "");
+        assert_eq!(catalog.description, "a description");
         assert_eq!(catalog.r#type, "Catalog");
         assert_eq!(catalog.version, STAC_VERSION);
         assert!(catalog.extensions.is_none());
@@ -117,7 +118,7 @@ mod tests {
 
     #[test]
     fn skip_serializing() {
-        let catalog = Catalog::new("an-id");
+        let catalog = Catalog::new("an-id", "a description");
         let value = serde_json::to_value(catalog).unwrap();
         assert!(value.get("stac_extensions").is_none());
         assert!(value.get("title").is_none());

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -152,18 +152,20 @@ impl Collection {
     ///
     /// ```
     /// use stac::Collection;
-    /// let collection = Collection::new("an-id");
+    /// let collection = Collection::new("an-id", "a description");
     /// assert_eq!(collection.id, "an-id");
+    /// assert_eq!(collection.description, "a description");
     /// ```
-    pub fn new(id: impl ToString) -> Collection {
+    pub fn new(id: impl ToString, description: impl ToString) -> Collection {
         Collection {
             r#type: COLLECTION_TYPE.to_string(),
             version: STAC_VERSION.to_string(),
             extensions: None,
             id: id.to_string(),
             title: None,
-            description: String::new(),
+            description: description.to_string(),
             keywords: None,
+            // TODO set a valid license by default
             license: String::new(),
             providers: None,
             extent: Extent::default(),
@@ -242,9 +244,9 @@ mod tests {
 
         #[test]
         fn new() {
-            let collection = Collection::new("an-id");
+            let collection = Collection::new("an-id", "a description");
             assert!(collection.title.is_none());
-            assert_eq!(collection.description, "");
+            assert_eq!(collection.description, "a description");
             assert_eq!(collection.license, "");
             assert!(collection.providers.is_none());
             assert_eq!(collection.extent, Extent::default());
@@ -259,7 +261,7 @@ mod tests {
 
         #[test]
         fn skip_serializing() {
-            let collection = Collection::new("an-id");
+            let collection = Collection::new("an-id", "a description");
             let value = serde_json::to_value(collection).unwrap();
             assert!(value.get("stac_extensions").is_none());
             assert!(value.get("title").is_none());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,13 +20,13 @@
 //! - [Collection] shares all fields with the `Catalog` (with different allowed values for `type` and `stac_extensions`) and adds fields to describe the whole dataset and the included set of `Items`
 //!
 //! All three are provided as [serde](https://serde.rs/) (de)serializable structures with public attributes.
-//! Each structure provides a `new` method that takes an `id` and fills the rest of the object's attributes with sensible defaults:
+//! Each structure provides a `new` method that fills most of the object's attributes with sensible defaults:
 //!
 //! ```
 //! use stac::{Item, Catalog, Collection};
 //! let item = Item::new("id");
-//! let catalog = Catalog::new("id");
-//! let collection = Catalog::new("id");
+//! let catalog = Catalog::new("id", "description");
+//! let collection = Catalog::new("id", "description");
 //! ```
 //!
 //! All attributes of STAC objects are accessible as public members:

--- a/src/value.rs
+++ b/src/value.rs
@@ -63,7 +63,7 @@ impl Value {
     ///
     /// ```
     /// # use stac::{Value, Catalog};
-    /// assert!(Value::Catalog(Catalog::new("an-id")).is_catalog());
+    /// assert!(Value::Catalog(Catalog::new("an-id", "a description")).is_catalog());
     /// ```
     pub fn is_catalog(&self) -> bool {
         matches!(self, Value::Catalog(_))
@@ -75,7 +75,7 @@ impl Value {
     ///
     /// ```
     /// # use stac::{Value, Catalog};
-    /// let value = Value::Catalog(Catalog::new("an-id"));
+    /// let value = Value::Catalog(Catalog::new("an-id", "a description"));
     /// assert_eq!(value.as_catalog().unwrap().id, "an-id");
     /// ```
     pub fn as_catalog(&self) -> Option<&Catalog> {
@@ -92,7 +92,7 @@ impl Value {
     ///
     /// ```
     /// # use stac::{Value, Catalog};
-    /// let mut value = Value::Catalog(Catalog::new("an-id"));
+    /// let mut value = Value::Catalog(Catalog::new("an-id", "a description"));
     /// value.as_mut_catalog().unwrap().id = "another-id".to_string();
     /// ```
     pub fn as_mut_catalog(&mut self) -> Option<&mut Catalog> {
@@ -109,7 +109,7 @@ impl Value {
     ///
     /// ```
     /// # use stac::{Value, Collection};
-    /// assert!(Value::Collection(Collection::new("an-id")).is_collection());
+    /// assert!(Value::Collection(Collection::new("an-id", "a description")).is_collection());
     /// ```
     pub fn is_collection(&self) -> bool {
         matches!(self, Value::Collection(_))
@@ -121,7 +121,7 @@ impl Value {
     ///
     /// ```
     /// # use stac::{Value, Collection};
-    /// let value = Value::Collection(Collection::new("an-id"));
+    /// let value = Value::Collection(Collection::new("an-id", "a description"));
     /// assert_eq!(value.as_collection().unwrap().id, "an-id");
     /// ```
     pub fn as_collection(&self) -> Option<&Collection> {
@@ -138,7 +138,7 @@ impl Value {
     ///
     /// ```
     /// # use stac::{Value, Collection};
-    /// let mut value = Value::Collection(Collection::new("an-id"));
+    /// let mut value = Value::Collection(Collection::new("an-id", "a description"));
     /// value.as_mut_collection().unwrap().id = "another-id".to_string();
     /// ```
     pub fn as_mut_collection(&mut self) -> Option<&mut Collection> {
@@ -407,7 +407,7 @@ mod tests {
 
     #[test]
     fn catalog_into_json_incorrect_type() {
-        let mut catalog = Catalog::new("an-id");
+        let mut catalog = Catalog::new("an-id", "a description");
         catalog.r#type = "Schmatalog".to_string();
         assert!(matches!(
             serde_json::Value::try_from(Value::Catalog(catalog)).unwrap_err(),
@@ -417,7 +417,7 @@ mod tests {
 
     #[test]
     fn collection_into_json_incorrect_type() {
-        let mut collection = Collection::new("an-id");
+        let mut collection = Collection::new("an-id", "a description");
         collection.r#type = "Scmalection".to_string();
         assert!(matches!(
             serde_json::Value::try_from(Value::Collection(collection)).unwrap_err(),


### PR DESCRIPTION
## Closes

- Closes #98 

## Description

Because valid collections and catalogs need a non-empty description field, it makes sense to require description for the initializer.

BREAKING CHANGE: changes the signature of the `new` methods

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
