### PR TITLE
Set the default license for collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `description` to `Catalog::new` and `Collection::new` ([#102](https://github.com/gadomski/stac-rs/pull/102))
 
+### Fixed
+
+- `Collections::new` sets a valid license ("proprietary") ([#104](https://github.com/gadomski/stac-rs/pull/104))
+
 ## [0.1.2] - 2022-12-08
 
 ### Added

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -6,6 +6,8 @@ use std::collections::HashMap;
 /// The type field for [Collections](Collection).
 pub const COLLECTION_TYPE: &str = "Collection";
 
+const DEFAULT_LICENSE: &str = "proprietary";
+
 /// The STAC `Collection` Specification defines a set of common fields to describe
 /// a group of [Items](crate::Item) that share properties and metadata.
 ///
@@ -165,8 +167,7 @@ impl Collection {
             title: None,
             description: description.to_string(),
             keywords: None,
-            // TODO set a valid license by default
-            license: String::new(),
+            license: DEFAULT_LICENSE.to_string(),
             providers: None,
             extent: Extent::default(),
             summaries: None,
@@ -247,7 +248,7 @@ mod tests {
             let collection = Collection::new("an-id", "a description");
             assert!(collection.title.is_none());
             assert_eq!(collection.description, "a description");
-            assert_eq!(collection.license, "");
+            assert_eq!(collection.license, "proprietary");
             assert!(collection.providers.is_none());
             assert_eq!(collection.extent, Extent::default());
             assert!(collection.summaries.is_none());


### PR DESCRIPTION
## Checklist

- [x] Unit tests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
