### PR TITLE
Make relative hrefs absolute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - `Extensions` trait ([#105](https://github.com/gadomski/stac-rs/pull/105))
 - `ItemCollection` ([#107](https://github.com/gadomski/stac-rs/pull/107))
 - `Value::type_name` ([#108](https://github.com/gadomski/stac-rs/pull/108))
+- `Links::make_relative_hrefs_absolute` ([#110](https://github.com/gadomski/stac-rs/pull/110))
+
+### Changed
+
+- Signature of `Error::MissingHref` (no longer takes a String) ([#110](https://github.com/gadomski/stac-rs/pull/110))
+- `Links` now requires `Href` ([#110](https://github.com/gadomski/stac-rs/pull/110))
 
 ### Fixed
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,8 +27,8 @@ pub enum Error {
     MissingType,
 
     /// Returned when an object is expected to have an href, but it doesn't.
-    #[error("object has no href: id={0}")]
-    MissingHref(String),
+    #[error("object has no href")]
+    MissingHref,
 
     /// This value is not an item.
     #[error("value is not an item")]


### PR DESCRIPTION
## Description

A little untested on the local paths side but it's cribbed from tested code so shrug.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
