### PR TITLE
Remove deprecated error type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `Collections::new` sets a valid license ("proprietary") ([#104](https://github.com/gadomski/stac-rs/pull/104))
 
+### Removed
+
+- `Error::TypeMismatch`, depreacted since v0.1.1 ([#111](https://github.com/gadomski/stac-rs/pull/111))
+
 ## [0.1.2] - 2022-12-08
 
 ### Added

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,16 +55,6 @@ pub enum Error {
     #[error("serde_json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
 
-    /// Mismatch between expected and actual type fields.
-    #[error("type mismatch: expected={expected}, actual={actual}")]
-    #[deprecated(since = "0.1.1", note = "use Error::IncorrecType instead")]
-    TypeMismatch {
-        /// The expected type field.
-        expected: String,
-        /// The actual type field.
-        actual: String,
-    },
-
     /// Returned when the `type` field of a STAC object does not equal `"Feature"`, `"Catalog"`, or `"Collection"`.
     #[error("unknown \"type\": {0}")]
     UnknownType(String),


### PR DESCRIPTION
## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
