### PR TITLE
make ItemCollection 'links' field public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Reorganized to a workspace ([#114](https://github.com/gadomski/stac-rs/pull/114))
+- `ItemCollection::links` is now public ([#115](https://github.com/gadomski/stac-rs/pull/115))
 
 ## [0.2.0] - 2022-12-29
 

--- a/stac/src/item.rs
+++ b/stac/src/item.rs
@@ -97,8 +97,9 @@ pub struct ItemCollection {
     #[serde(rename = "features")]
     pub items: Vec<Item>,
 
+    /// List of link objects to resources and related URLs.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    links: Vec<Link>,
+    pub links: Vec<Link>,
 
     #[serde(skip)]
     href: Option<String>,


### PR DESCRIPTION
## Closes

- n/a

## Related to

- n/a

## Description

ItemCollection `links` was not pub, so a user outside this module cannot access it. A specific use case this prevents is retreiving search results from a STAC API and then using the `next` link to get the next page of results.

## Checklist

Delete any checklist items that do not apply (e.g. if your change is minor, it may not require documentation updates).

- [ ] Unit tests
- [x] Documentation, including doctests
- [X] Git history is linear
- [X] Commit messages are descriptive
- [ ] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Code is formatted (`cargo fmt`)
- [X] `cargo test`
- [x] Changes are added to the CHANGELOG
