### PR TITLE
`make_relative_links_absolute` now takes an href

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}${{ matrix.flags }}
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
       - name: Format
         run: cargo fmt --verbose
       - name: Build
@@ -41,14 +34,7 @@ jobs:
       RUSTDOCFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
       - name: Doc
         run: cargo doc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 
-- `Error::TypeMismatch`, depreacted since v0.1.1 ([#111](https://github.com/gadomski/stac-rs/pull/111))
+- `Error::TypeMismatch`, deprecated since v0.1.1 ([#111](https://github.com/gadomski/stac-rs/pull/111))
 
 ## [0.1.2] - 2022-12-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Added
-
 ### Changed
 
 - Reorganized to a workspace ([#114](https://github.com/gadomski/stac-rs/pull/114))
 - `ItemCollection::links` is now public ([#115](https://github.com/gadomski/stac-rs/pull/115))
+- `Links::make_relative_links_absolute` takes the href as an argument, and `Links` does not require `Href` ([#116](https://github.com/gadomski/stac-rs/pull/116))
 
 ## [0.2.0] - 2022-12-29
 

--- a/stac/src/link.rs
+++ b/stac/src/link.rs
@@ -100,8 +100,6 @@ pub trait Links {
     /// This will remove all other links of that rel type, so should only be
     /// used for e.g. "root", not e.g. "child".
     ///
-    /// Returns a vector of all removed links.
-    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
## Description

This lets use remove the Href constraints for links, since not everything that has links needs to have an href.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
