### PR TITLE
Add Item::collection setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `Item::collection` setter in the builder pattern ([#117](https://github.com/gadomski/stac-rs/pull/117))
+
 ## [0.3.0] - 2023-01-08
 
 ### Changed

--- a/stac/src/item.rs
+++ b/stac/src/item.rs
@@ -158,6 +158,19 @@ impl Item {
         }
     }
 
+    /// Sets this item's collection id in the builder pattern.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use stac::Item;
+    /// let item = Item::new("an-id").collection("a-collection");
+    /// assert_eq!(item.collection.unwrap(), "a-collection");
+    pub fn collection(mut self, id: impl ToString) -> Item {
+        self.collection = Some(id.to_string());
+        self
+    }
+
     /// Returns this item's collection link.
     ///
     /// This is the first link with a rel="collection".


### PR DESCRIPTION
## Description

I have a feeling we'll accumulate these builder-pattern setters all over the place as we find them useful. Not the worst thing, but I just don't want to make them all right now.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
