### PR TITLE
Add stac-api crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
     "stac",
+    "stac-api",
     "stac-async",
 ]

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # stac-rs
 
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/gadomski/stac-rs/ci.yml?branch=main&style=for-the-badge)](https://github.com/gadomski/stac-rs/actions/workflows/ci.yml)
-![Crates.io](https://img.shields.io/crates/l/stac?style=for-the-badge)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=for-the-badge)](./CODE_OF_CONDUCT)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/gadomski/stac-rs/ci.yml?branch=main&style=flat-square)](https://github.com/gadomski/stac-rs/actions/workflows/ci.yml)
+![Crates.io](https://img.shields.io/crates/l/stac?style=flat-square)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=flat-square)](./CODE_OF_CONDUCT)
 
-[![docs.rs](https://img.shields.io/docsrs/stac?style=for-the-badge&label=docs(stac))](https://docs.rs/stac/latest/stac/)
-[![Crates.io](https://img.shields.io/crates/v/stac?style=for-the-badge&label=crates.io(stac))](https://crates.io/crates/stac)
-
-[![docs.rs](https://img.shields.io/docsrs/stac-async?style=for-the-badge&label=docs(stac-async))](https://docs.rs/stac-async/latest/stac_async/)
-[![Crates.io](https://img.shields.io/crates/v/stac-async?style=for-the-badge&label=crates.io(stac-async))](https://crates.io/crates/stac-async)
-
-Rust implementation of the [SpatioTemporal Asset Catalog (STAC)](https://stacspec.org/) specification.
+Rust implementation of the [SpatioTemporal Asset Catalog (STAC)](https://stacspec.org/) specification, spread over several crates.
 
 <p align="center">
-<img src="https://d33wubrfki0l68.cloudfront.net/22691a3c3002324451ed99f4009de8aab761e1b7/d24da/public/images-original/stac-01.png" height="100">
+<img src="https://github.com/radiantearth/stac-site/raw/main/assets/images/STAC-01.png" height="100">
 <img src="https://rustacean.net/assets/rustacean-orig-noshadow.svg" height=100>
 </p>
+
+| Crate | Description | Readme | Docs | Crates.io |
+| ----- | ---- | --------- | -- | -- |
+| **stac** | Core data structures and synchronous I/O | [![README](https://img.shields.io/static/v1?label=README&message=stac&color=informational&style=flat-square)](./stac/README.md) | [![docs.rs](https://img.shields.io/docsrs/stac?style=flat-square)](https://docs.rs/stac/latest/stac/) | [![Crates.io](https://img.shields.io/crates/v/stac?style=flat-square)](https://crates.io/crates/stac) |
+| **stac-async** | Asynchronous I/O with [tokio](https://tokio.rs/) | [![README](https://img.shields.io/static/v1?label=README&message=stac-async&color=informational&style=flat-square)](./stac-async/README.md) | [![docs.rs](https://img.shields.io/docsrs/stac-async?style=flat-square)](https://docs.rs/stac-async/latest/stac_async/) | [![Crates.io](https://img.shields.io/crates/v/stac-async?style=flat-square)](https://crates.io/crates/stac-async)
+| **stac-api** | Data structures for the [STAC API](https://github.com/radiantearth/stac-api-spec) specification | [![README](https://img.shields.io/static/v1?label=README&message=stac-api&color=informational&style=flat-square)](./stac-api/README.md) | [![docs.rs](https://img.shields.io/docsrs/stac-api?style=flat-square)](https://docs.rs/stac-api/latest/stac_api/) | [![Crates.io](https://img.shields.io/crates/v/stac-api?style=flat-square)](https://crates.io/crates/stac-api)
 
 ## Usage
 
@@ -34,10 +34,12 @@ stac = "0.3"
 stac-async = "0.3"
 ```
 
-## More information
+If you're using [STAC API](https://github.com/radiantearth/stac-api-spec) data structures:
 
-- **stac**: [README](./stac/README.md) and [documentation](https://docs.rs/stac)
-- **stac-async**: [README](./stac-async/README.md) and [documentation](https://docs.rs/stac-async)
+```toml
+[dependencies]
+stac-api = "0.1"
+```
 
 ## Development
 

--- a/stac-api/CHANGELOG.md
+++ b/stac-api/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2023-01-14
+
+Initial release
+
+[unreleased]: https://github.com/gadomski/stac-rs/compare/stac-api-v0.1.0...main
+[0.1.0]: https://github.com/gadomski/stac-rs/releases/tag/stac-api-v0.1.0

--- a/stac-api/Cargo.toml
+++ b/stac-api/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "stac-api"
+version = "0.1.0"
+authors = ["Pete Gadomski <pete.gadomski@gmail.com>"]
+edition = "2021"
+description = "Rust library for the SpatioTemporal Asset Catalog (STAC) API specification"
+homepage = "https://github.com/gadomski/stac-rs"
+repository = "https://github.com/gadomski/stac-rs"
+license = "MIT OR Apache-2.0"
+keywords = ["geospatial", "stac", "metadata", "geo", "raster"]
+categories = ["science", "data-structures", "web-programming"]
+
+[dependencies]
+geojson = "0.24"
+serde = "1"
+serde_json = "1"
+serde_urlencoded = "0.7"
+stac = { version = "0.3", path = "../stac" }
+thiserror = "1"
+url = "2.3"

--- a/stac-api/src/collections.rs
+++ b/stac-api/src/collections.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use stac::{Collection, Link};
+
+/// Object containing an array of Collection objects in the Catalog, and Link relations.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Collections {
+    /// The [Collection] objects in the [stac::Catalog].
+    pub collections: Vec<Collection>,
+
+    /// The [stac::Link] relations.
+    pub links: Vec<Link>,
+
+    /// Additional fields.
+    #[serde(flatten)]
+    pub additional_fields: Map<String, Value>,
+}

--- a/stac-api/src/error.rs
+++ b/stac-api/src/error.rs
@@ -1,0 +1,21 @@
+use thiserror::Error;
+
+/// Crate-specific error enum.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// [serde_json::Error]
+    #[error(transparent)]
+    SerdeJson(#[from] serde_json::Error),
+
+    /// [serde_urlencoded::ser::Error]
+    #[error(transparent)]
+    SerdeUrlencodedSer(#[from] serde_urlencoded::ser::Error),
+
+    /// [std::num::TryFromIntError]
+    #[error(transparent)]
+    TryFromInt(#[from] std::num::TryFromIntError),
+
+    /// [url::ParseError]
+    #[error(transparent)]
+    UrlParse(#[from] url::ParseError),
+}

--- a/stac-api/src/fields.rs
+++ b/stac-api/src/fields.rs
@@ -1,0 +1,80 @@
+use serde::{Deserialize, Serialize};
+use std::{convert::Infallible, str::FromStr};
+
+/// Include/exclude fields from item collections.
+///
+/// By default, STAC API endpoints that return Item objects return every field
+/// of those Items. However, Item objects can have hundreds of fields, or large
+/// geometries, and even smaller Item objects can add up when large numbers of
+/// them are in results. Frequently, not all fields in an Item are used, so this
+/// specification provides a mechanism for clients to request that servers to
+/// explicitly include or exclude certain fields.
+#[derive(Debug, Serialize, Deserialize, Default, PartialEq)]
+pub struct Fields {
+    /// Fields to include.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub include: Vec<String>,
+
+    /// Fields to exclude.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub exclude: Vec<String>,
+}
+
+impl FromStr for Fields {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut include = Vec::new();
+        let mut exclude = Vec::new();
+        for field in s.split(",").filter(|s| !s.is_empty()) {
+            if field.starts_with('-') {
+                exclude.push(field[1..].to_string());
+            } else {
+                include.push(field.to_string());
+            }
+        }
+        Ok(Fields { include, exclude })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Fields;
+
+    #[test]
+    fn empty() {
+        assert_eq!(Fields::default(), "".parse().unwrap());
+    }
+
+    #[test]
+    fn includes() {
+        assert_eq!(
+            Fields {
+                include: vec![
+                    "id".to_string(),
+                    "type".to_string(),
+                    "geometry".to_string(),
+                    "bbox".to_string(),
+                    "properties".to_string(),
+                    "links".to_string(),
+                    "assets".to_string(),
+                ],
+                exclude: Vec::new()
+            },
+            "id,type,geometry,bbox,properties,links,assets"
+                .parse()
+                .unwrap()
+        )
+    }
+
+    #[test]
+    fn exclude() {
+        assert_eq!(
+            Fields {
+                include: Vec::new(),
+                exclude: vec!["geometry".to_string()]
+            },
+            "-geometry".parse().unwrap()
+        );
+    }
+}

--- a/stac-api/src/item_collection.rs
+++ b/stac-api/src/item_collection.rs
@@ -1,0 +1,86 @@
+use crate::{Item, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use stac::Link;
+
+const ITEM_COLLECTION_TYPE: &str = "FeatureCollection";
+
+/// The return value of the `/items` and `/search` endpoints.
+///
+/// This might be a [stac::ItemCollection], but if the [fields
+/// extension](https://github.com/stac-api-extensions/fields) is used, it might
+/// not be. Defined by the [itemcollection
+/// fragment](https://github.com/radiantearth/stac-api-spec/blob/main/fragments/itemcollection/README.md).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ItemCollection {
+    /// Always "FeatureCollection" to provide compatibility with GeoJSON.
+    pub r#type: String,
+
+    /// A possibly-empty array of Item objects.
+    pub features: Vec<Item>,
+
+    /// An array of Links related to this ItemCollection.
+    pub links: Vec<Link>,
+
+    /// The number of Items that meet the selection parameters, possibly estimated.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "numberMatched")]
+    pub number_matched: Option<u64>,
+
+    /// The number of Items in the features array.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "numberReturned")]
+    pub number_returned: Option<u64>,
+
+    /// The search-related metadata for the [ItemCollection].
+    ///
+    /// Part of the [context extension](https://github.com/stac-api-extensions/context).
+    pub context: Option<Context>,
+
+    /// Additional fields.
+    #[serde(flatten)]
+    pub additional_fields: Map<String, Value>,
+}
+
+/// The search-related metadata for the [ItemCollection].
+///
+/// Part of the [context extension](https://github.com/stac-api-extensions/context).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Context {
+    /// The count of results returned by this response. Equal to the cardinality
+    /// of features array.
+    pub returned: u64,
+
+    /// The maximum number of results to which the result was limited.
+    pub limit: Option<u64>,
+
+    /// The count of total number of results that match for this query, possibly
+    /// estimated, particularly in the context of NoSQL data stores.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub matched: Option<u64>,
+
+    /// Additional fields.
+    #[serde(flatten)]
+    pub additional_fields: Map<String, Value>,
+}
+
+impl ItemCollection {
+    /// Creates a new [ItemCollection] from a vector of items.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let item: stac_api::Item = stac::Item::new("an-id").try_into().unwrap();
+    /// let item_collection = stac_api::ItemCollection::new(vec![item]).unwrap();
+    /// ```
+    pub fn new(items: Vec<Item>) -> Result<ItemCollection> {
+        let number_returned = items.len();
+        Ok(ItemCollection {
+            r#type: ITEM_COLLECTION_TYPE.to_string(),
+            features: items,
+            links: Vec::new(),
+            number_matched: None,
+            number_returned: Some(number_returned.try_into()?),
+            context: None,
+            additional_fields: Map::new(),
+        })
+    }
+}

--- a/stac-api/src/lib.rs
+++ b/stac-api/src/lib.rs
@@ -1,0 +1,108 @@
+//! Rust implementation of the STAC API specification.
+//!
+//! This crate **is**:
+//!
+//! - Data structures
+//! - Link building
+//!
+//! This crate **is not**:
+//!
+//! - A server implementation
+//!
+//! For a STAC API server written in Rust, based on this crate, see
+//! [stac-server-rs](http://github.com/gadomski/stac-server-rs).
+//!
+//! # Data structures
+//!
+//! Each API endpoint has its own data structure. In some cases, these are
+//! light wrappers around [stac] data structures. In other cases, they can be
+//! different -- e.g. the `/search` endpoint may not return [Items](stac::Item)
+//! if the [fields](https://github.com/stac-api-extensions/fields) extension is
+//! used, so the return type is a crate-specific [Item] struct.
+//!
+//! For example, here's the root structure (a.k.a the landing page):
+//!
+//! ```
+//! use stac::Catalog;
+//! use stac_api::Root;
+//! let root = Root {
+//!     catalog: Catalog::new("an-id", "a description"),
+//!     conforms_to: vec!["https://api.stacspec.org/v1.0.0-rc.2/core".to_string()],
+//! };
+//! ```
+//!
+//! # Build links
+//!
+//! The [LinkBuilder] structure can build links to parts of a STAC API.
+//! A [LinkBuilder] is created from a root href:
+//!
+//! ```
+//! use stac_api::LinkBuilder;
+//! let link_builder: LinkBuilder = "http://stac-api-rs.test/api/v1".parse().unwrap();
+//! ```
+//!
+//! Link builders provide a variety of methods for building links to all parts of a STAC API:
+//!
+//! ```
+//! # use stac_api::LinkBuilder;
+//! # let link_builder: LinkBuilder = "http://stac-api-rs.test/api/v1".parse().unwrap();
+//! let link = link_builder.items("a-collection-id", [("limit", "10")]).unwrap();
+//! assert_eq!(link.href, "http://stac-api-rs.test/api/v1/collections/a-collection-id/items?limit=10");
+//! ```
+
+#![deny(missing_docs, unused_extern_crates)]
+
+mod collections;
+mod error;
+mod fields;
+mod item_collection;
+mod link;
+mod link_builder;
+mod root;
+mod search;
+mod sort;
+
+pub use {
+    collections::Collections,
+    error::Error,
+    fields::Fields,
+    item_collection::{Context, ItemCollection},
+    link::Link,
+    link_builder::LinkBuilder,
+    root::Root,
+    search::Search,
+    sort::Sortby,
+};
+
+/// Crate-specific result type.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// A crate-specific STAC Item struct.
+///
+/// By default, STAC API endpoints that return [stac::Item] objects return every
+/// field of those Items. However, Item objects can have hundreds of fields, or
+/// large geometries, and even smaller Item objects can add up when large
+/// numbers of them are in results. Frequently, not all fields in an Item are
+/// used, so this specification provides a mechanism for clients to request that
+/// servers to explicitly include or exclude certain fields.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct Item(pub serde_json::Map<String, serde_json::Value>);
+
+impl TryFrom<stac::Item> for Item {
+    type Error = serde_json::Error;
+
+    fn try_from(item: stac::Item) -> std::result::Result<Item, serde_json::Error> {
+        match serde_json::to_value(item)? {
+            serde_json::Value::Object(object) => Ok(Item(object)),
+            _ => panic!("a STAC item shouldn't be able to deserialize to anything but an object"),
+        }
+    }
+}
+
+impl TryFrom<Item> for stac::Item {
+    type Error = serde_json::Error;
+
+    fn try_from(item: Item) -> std::result::Result<stac::Item, serde_json::Error> {
+        serde_json::from_value(serde_json::Value::Object(item.0))
+    }
+}

--- a/stac-api/src/link.rs
+++ b/stac-api/src/link.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// Crate-specific link type.
+///
+/// The item search conformance class defines some additional fields on link.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Link {
+    #[serde(flatten)]
+    link: stac::Link,
+
+    /// The HTTP method of the request, usually GET or POST. Defaults to GET.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    method: Option<String>,
+
+    /// A dictionary of header values that must be included in the next request
+    #[serde(skip_serializing_if = "Map::is_empty")]
+    headers: Map<String, Value>,
+
+    /// If true, the headers/body fields in the next link must be merged into
+    /// the original request and be sent combined in the next request. Defaults
+    /// to false
+    #[serde(skip_serializing_if = "Option::is_none")]
+    merge: Option<bool>,
+}

--- a/stac-api/src/link_builder.rs
+++ b/stac-api/src/link_builder.rs
@@ -1,0 +1,197 @@
+use crate::{Error, Result};
+use serde::Serialize;
+use stac::Link;
+use std::str::FromStr;
+use url::{ParseError, Url};
+
+/// Build links to endpoints in a STAC API.
+///
+/// # Examples
+///
+/// [LinkBuilder] can be parsed from a string:
+///
+/// ```
+/// # use stac_api::LinkBuilder;
+/// let link_builder: LinkBuilder = "http://stac-api-rs.test/api/v1".parse().unwrap();
+/// ```
+///
+/// Note that the root will always have a trailing slash, even if you didn't provide one:
+///
+/// ```
+/// # use stac_api::LinkBuilder;
+/// let link_builder: LinkBuilder = "http://stac-api-rs.test/api/v1".parse().unwrap();
+/// assert_eq!(link_builder.root().href, "http://stac-api-rs.test/api/v1/");
+/// ```
+#[derive(Debug)]
+pub struct LinkBuilder(Url);
+
+impl LinkBuilder {
+    /// Returns a root link.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac_api::LinkBuilder;
+    /// let link_builder: LinkBuilder = "http://stac-api-rs.test/api/v1".parse().unwrap();
+    /// let root = link_builder.root();
+    /// assert_eq!(root.rel, "root");
+    /// assert_eq!(root.href, "http://stac-api-rs.test/api/v1/");
+    /// ```
+    pub fn root(&self) -> Link {
+        Link::root(self.0.as_str())
+    }
+
+    /// Returns a root's self link.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac_api::LinkBuilder;
+    /// let link_builder: LinkBuilder = "http://stac-api-rs.test/api/v1".parse().unwrap();
+    /// let root = link_builder.root_self();
+    /// assert_eq!(root.rel, "self");
+    /// assert_eq!(root.href, "http://stac-api-rs.test/api/v1/");
+    /// ```
+    pub fn root_self(&self) -> Link {
+        Link::self_(self.0.as_str())
+    }
+
+    /// Returns an child link for a collection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac_api::LinkBuilder;
+    /// let link_builder: LinkBuilder = "http://stac-api-rs.test/api/v1".parse().unwrap();
+    /// let link = link_builder.child_collection("an-id").unwrap();
+    /// assert_eq!(link.rel, "child");
+    /// assert_eq!(link.href, "http://stac-api-rs.test/api/v1/collections/an-id");
+    /// ```
+    pub fn child_collection(&self, id: &str) -> Result<Link> {
+        self.0
+            .join(&format!("collections/{}", id))
+            .map(Link::child)
+            .map_err(Error::from)
+    }
+
+    /// Returns a parent link for a collection.
+    ///
+    /// This is just the root url.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac_api::LinkBuilder;
+    /// let link_builder: LinkBuilder = "http://stac-api-rs.test/api/v1".parse().unwrap();
+    /// let link = link_builder.collection_parent();
+    /// assert_eq!(link.rel, "parent");
+    /// assert_eq!(link.href, "http://stac-api-rs.test/api/v1/");
+    /// ```
+    pub fn collection_parent(&self) -> Link {
+        Link::parent(self.0.as_str())
+    }
+
+    /// Returns a self link for a collection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac_api::LinkBuilder;
+    /// let link_builder: LinkBuilder = "http://stac-api-rs.test/api/v1".parse().unwrap();
+    /// let link = link_builder.collection_self("an-id").unwrap();
+    /// assert_eq!(link.rel, "self");
+    /// assert_eq!(link.href, "http://stac-api-rs.test/api/v1/collections/an-id");
+    /// ```
+    pub fn collection_self(&self, id: &str) -> Result<Link> {
+        self.0
+            .join(&format!("collections/{}", id))
+            .map(Link::self_)
+            .map_err(Error::from)
+    }
+
+    /// Returns an items link for a collection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac_api::LinkBuilder;
+    /// let link_builder: LinkBuilder = "http://stac-api-rs.test/api/v1".parse().unwrap();
+    /// let link = link_builder.items("an-id", ()).unwrap();
+    /// assert_eq!(link.rel, "items");
+    /// assert_eq!(link.href, "http://stac-api-rs.test/api/v1/collections/an-id/items");
+    /// ```
+    pub fn items<S>(&self, id: &str, parameters: S) -> Result<Link>
+    where
+        S: Serialize,
+    {
+        self.items_with_rel(id, parameters, "items")
+    }
+
+    /// Returns a next items link for a collection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac_api::LinkBuilder;
+    /// let link_builder: LinkBuilder = "http://stac-api-rs.test/api/v1".parse().unwrap();
+    /// let link = link_builder.next_items("an-id", [("foo", "bar")]).unwrap();
+    /// assert_eq!(link.rel, "next");
+    /// assert_eq!(link.href, "http://stac-api-rs.test/api/v1/collections/an-id/items?foo=bar");
+    /// ```
+    pub fn next_items<S>(&self, id: &str, parameters: S) -> Result<Link>
+    where
+        S: Serialize,
+    {
+        self.items_with_rel(id, parameters, "next")
+    }
+
+    /// Returns a prev items link for a collection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac_api::LinkBuilder;
+    /// let link_builder: LinkBuilder = "http://stac-api-rs.test/api/v1".parse().unwrap();
+    /// let link = link_builder.prev_items("an-id", [("foo", "bar")]).unwrap();
+    /// assert_eq!(link.rel, "prev");
+    /// assert_eq!(link.href, "http://stac-api-rs.test/api/v1/collections/an-id/items?foo=bar");
+    /// ```
+    pub fn prev_items<S>(&self, id: &str, parameters: S) -> Result<Link>
+    where
+        S: Serialize,
+    {
+        self.items_with_rel(id, parameters, "prev")
+    }
+
+    fn items_with_rel<S>(&self, id: &str, parameters: S, rel: impl ToString) -> Result<Link>
+    where
+        S: Serialize,
+    {
+        self.0
+            .join(&format!("collections/{}/items", id))
+            .map_err(Error::from)
+            .and_then(|url| {
+                serde_urlencoded::to_string(parameters)
+                    .map(|query| (url, query))
+                    .map_err(Error::from)
+            })
+            .map(|(mut url, query)| {
+                if !query.is_empty() {
+                    url.set_query(Some(&query));
+                }
+                Link::new(url, rel).geojson()
+            })
+    }
+}
+
+impl FromStr for LinkBuilder {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        if s.ends_with('/') {
+            s.parse().map(LinkBuilder)
+        } else {
+            format!("{}/", s).parse().map(LinkBuilder)
+        }
+    }
+}

--- a/stac-api/src/root.rs
+++ b/stac-api/src/root.rs
@@ -1,0 +1,60 @@
+use serde::{Deserialize, Serialize};
+use stac::Catalog;
+
+/// The root landing page of a STAC API.
+///
+/// In a STAC API, the root endpoint (Landing Page) has the following characteristics:
+///
+///   - The returned JSON is a [STAC
+///     Catalog](../stac-spec/catalog-spec/catalog-spec.md), and provides any number
+///     of 'child' links to navigate to additional
+///     [Catalog](../stac-spec/catalog-spec/catalog-spec.md),
+///     [Collection](../stac-spec/collection-spec/README.md), and
+///     [Item](../stac-spec/item-spec/README.md) objects.
+///   - The `links` attribute is part of a STAC Catalog, and provides a list of
+///     relations to API endpoints. Some of these endpoints can exist on any path
+///     (e.g., sub-catalogs) and some have a specified path (e.g., `/search`), so
+///     the client must inspect the `rel` (relationship) to understand what
+///     capabilities are offered at each location.
+///   - The `conformsTo` section provides the capabilities of this service. This
+///     is the field that indicates to clients that this is a STAC API and how to
+///     access conformance classes, including this one. The relevant conformance
+///     URIs are listed in each part of the API specification. If a conformance
+///     URI is listed then the service must implement all of the required
+///     capabilities.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Root {
+    /// The [stac::Catalog].
+    #[serde(flatten)]
+    pub catalog: Catalog,
+
+    /// Provides the capabilities of this service.
+    ///
+    /// This is the field that indicates to clients that this is a STAC API and
+    /// how to access conformance classes, including this one. The relevant
+    /// conformance URIs are listed in each part of the API specification. If a
+    /// conformance URI is listed then the service must implement all of the
+    /// required capabilities.
+    ///
+    /// Note the `conformsTo` array follows the same structure of the OGC API -
+    /// Features [declaration of conformance
+    /// classes](http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#_declaration_of_conformance_classes),
+    /// except it is part of the landing page instead of in the JSON response
+    /// from the `/conformance` endpoint. This is different from how the OGC API
+    /// advertises conformance, as STAC feels it is important for clients to
+    /// understand conformance from a single request to the landing page.
+    /// Implementers who implement the *OGC API - Features* and/or *STAC API -
+    /// Features* conformance classes must also implement the `/conformance`
+    /// endpoint.
+    ///
+    /// The scope of the conformance classes declared in the
+    /// `conformsTo` field and the `/conformance` endpoint are limited to the
+    /// STAC API Catalog that declares them. A STAC API Catalog may link to
+    /// sub-catalogs within it via `child` links that declare different
+    /// conformance classes. This is useful when an entire catalog cannot be
+    /// searched against to support the *STAC API - Item Search* conformance
+    /// class, perhaps because it uses multiple databases to store items, but
+    /// sub-catalogs whose items are all in one database can support search.
+    /// #[serde(rename = "conformsTo")]
+    pub conforms_to: Vec<String>,
+}

--- a/stac-api/src/search.rs
+++ b/stac-api/src/search.rs
@@ -1,0 +1,78 @@
+use crate::{Fields, Sortby};
+use geojson::Geometry;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// The core parameters for STAC search are defined by OAFeat, and STAC adds a few parameters for convenience.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Search {
+    /// The maximum number of results to return (page size).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u64>,
+
+    /// Requested bounding box.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub bbox: Vec<f64>,
+
+    /// Single date+time, or a range ('/' separator), formatted to [RFC 3339,
+    /// section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6).
+    ///
+    /// Use double dots `..` for open date ranges.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub datetime: Option<String>,
+
+    /// Searches items by performing intersection between their geometry and provided GeoJSON geometry.
+    ///
+    /// All GeoJSON geometry types must be supported.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub intersects: Option<Geometry>,
+
+    /// Array of Item ids to return.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub ids: Vec<String>,
+
+    /// Array of one or more Collection IDs that each matching Item must be in.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub collections: Vec<String>,
+
+    /// Include/exclude fields from item collections.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fields: Option<Fields>,
+
+    /// Fields by which to sort results.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub sortby: Vec<Sortby>,
+
+    /// `cql2-text` or `cql2-json`.
+    ///
+    /// If undefined, defaults to `cql2-text` for a GET request and `cql2-json` for a POST request.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "filter-lang")]
+    pub filter_lang: Option<FilterLang>,
+
+    /// Recommended to not be passed, but server must only accept
+    /// <http://www.opengis.net/def/crs/OGC/1.3/CRS84> as a valid value, may
+    /// reject any others
+    #[serde(skip_serializing_if = "Option::is_none", rename = "filter-crs")]
+    pub filter_crs: Option<String>,
+
+    /// CQL2 filter expression.
+    #[serde(skip_serializing_if = "Map::is_empty")]
+    pub filter: Map<String, Value>,
+
+    /// Additional filtering based on properties.
+    ///
+    /// It is recommended to use the filter extension instead.
+    #[serde(skip_serializing_if = "Map::is_empty")]
+    pub query: Map<String, Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum FilterLang {
+    /// `cql2-text`
+    #[serde(rename = "cql2-text")]
+    Cql2Text,
+
+    /// `cql2-json`
+    #[serde(rename = "cql2-text")]
+    Cql2Json,
+}

--- a/stac-api/src/sort.rs
+++ b/stac-api/src/sort.rs
@@ -1,0 +1,133 @@
+use std::{convert::Infallible, str::FromStr};
+
+use serde::{Deserialize, Serialize};
+
+/// Fields by which to sort results.
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+pub struct Sortby {
+    /// The field to sort by.
+    pub field: String,
+
+    /// The direction to sort by.
+    pub direction: Direction,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+pub enum Direction {
+    #[serde(rename = "asc")]
+    Ascending,
+    #[serde(rename = "desc")]
+    Descending,
+}
+
+impl Sortby {
+    /// Creates a new ascending sortby for the field.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac_api::Sortby;
+    /// let sortby = Sortby::asc("id");
+    /// ```
+    pub fn asc(field: impl ToString) -> Sortby {
+        Sortby {
+            field: field.to_string(),
+            direction: Direction::Ascending,
+        }
+    }
+
+    /// Creates a new descending sortby for the field.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac_api::Sortby;
+    /// let sortby = Sortby::desc("id");
+    /// ```
+    pub fn desc(field: impl ToString) -> Sortby {
+        Sortby {
+            field: field.to_string(),
+            direction: Direction::Descending,
+        }
+    }
+
+    /// Creates a vector of [Sortbys](Sortby) from a comma-delimited list.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac_api::Sortby;
+    /// let sortbys = Sortby::from_query_param("+id,-datetime");
+    /// ```
+    pub fn from_query_param(s: &str) -> Vec<Sortby> {
+        s.split(',')
+            .filter_map(|s| {
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(s.parse().unwrap()) // infallible
+                }
+            })
+            .collect()
+    }
+}
+
+impl FromStr for Sortby {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.starts_with('+') {
+            Ok(Sortby::asc(&s[1..]))
+        } else if s.starts_with('-') {
+            Ok(Sortby::desc(&s[1..]))
+        } else {
+            Ok(Sortby::asc(s))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Sortby;
+    use serde_json::json;
+
+    #[test]
+    fn optional_plus() {
+        assert_eq!(
+            "properties.created".parse::<Sortby>().unwrap(),
+            "+properties.created".parse().unwrap()
+        );
+    }
+
+    #[test]
+    fn descending() {
+        assert_eq!(Sortby::desc("id"), "-id".parse().unwrap());
+    }
+
+    #[test]
+    fn ordering() {
+        assert_eq!(
+            vec![
+                Sortby::asc("properties.created"),
+                Sortby::desc("properties.eo:cloud_cover"),
+                Sortby::desc("id"),
+                Sortby::asc("collection")
+            ],
+            Sortby::from_query_param(
+                "+properties.created,-properties.eo:cloud_cover,-id,collection"
+            )
+        )
+    }
+
+    #[test]
+    fn names() {
+        assert_eq!(
+            json!({"field": "foo", "direction": "asc"}),
+            serde_json::to_value(Sortby::asc("foo")).unwrap()
+        );
+        assert_eq!(
+            json!({"field": "foo", "direction": "desc"}),
+            serde_json::to_value(Sortby::desc("foo")).unwrap()
+        );
+    }
+}


### PR DESCRIPTION
## Description

I was building the API crate over at [stac-server-rs](https://github.com/gadomski/stac-server-rs/blob/bc98dc916059ceb9e0bfd0f4241ec0b9586815e2/stac-api/src/lib.rs), but it was getting interesting enough for inclusion in the core repo, I think. Plus, now these data structures are reusable by other libraries -- e.g. I think I can use the search stuff in [pgstac-rs](https://github.com/gadomski/pgstac-rs/).

Once this PR merges, I'll release it as v0.1.0.

cc @philvarner b/c I know you were working w/ API-based data structures for [stac-siphon-rs](https://github.com/philvarner/stac-siphon-rs).

## Checklist


- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
