### PR TITLE
Adds Link::set_query

### DIFF
--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `Item::collection` setter in the builder pattern ([#117](https://github.com/gadomski/stac-rs/pull/117))
 - `Link::geojson` ([#119](https://github.com/gadomski/stac-rs/pull/119))
 - `Link::is_json` and `Link::is_geojson` ([#120](https://github.com/gadomski/stac-rs/pull/120))
-- `Link::set_query_pair` ([#121](https://github.com/gadomski/stac-rs/pull/121))
+- `Link::set_query` ([#127](https://github.com/gadomski/stac-rs/pull/127))
 
 ## [0.3.0] - 2023-01-08
 

--- a/stac/Cargo.toml
+++ b/stac/Cargo.toml
@@ -12,6 +12,8 @@ categories = ["science", "data-structures"]
 
 [features]
 jsonschema = ["dep:jsonschema", "reqwest"]
+reqwest = ["dep:reqwest"]
+set_query = ["dep:serde_urlencoded"]
 
 [dependencies]
 chrono = "0.4"
@@ -20,6 +22,7 @@ jsonschema = { version = "0.16", optional = true, features = ["resolve-http"], d
 reqwest = { version = "0.11", optional = true, features = ["json", "blocking"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
+serde_urlencoded = { version = "0.7", optional = true }
 thiserror = "1"
 url = "2"
 

--- a/stac/README.md
+++ b/stac/README.md
@@ -19,7 +19,7 @@ stac = "0.3"
 
 ### Features
 
-There are two opt-in features: `jsonschema` and `reqwest`.
+There are three opt-in features: `jsonschema`, `reqwest`, and `set_query`.
 
 #### jsonschema
 
@@ -42,6 +42,16 @@ stac = { version = "0.3", features = ["reqwest"]}
 ```
 
 If `reqwest` is not enabled, `stac::read` will throw an error if you try to read from a url.
+
+#### set_query
+
+The `set_query` feature adds a single method to `Link`.
+It is behind a feature because it adds a dependency, [serde_urlencoded](https://crates.io/crates/serde_urlencoded).
+To enable:
+
+```toml
+stac = { version = "0.3", features = ["set_query"]}
+```
 
 ## Examples
 

--- a/stac/src/error.rs
+++ b/stac/src/error.rs
@@ -55,6 +55,11 @@ pub enum Error {
     #[error("serde_json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
 
+    /// [serde_urlencoded::ser::Error]
+    #[cfg(feature = "set_query")]
+    #[error(transparent)]
+    SerdeUrlencodedSer(#[from] serde_urlencoded::ser::Error),
+
     /// Returned when the `type` field of a STAC object does not equal `"Feature"`, `"Catalog"`, or `"Collection"`.
     #[error("unknown \"type\": {0}")]
     UnknownType(String),

--- a/stac/src/error.rs
+++ b/stac/src/error.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum Error {
     /// [std::io::Error]
-    #[error("std::io error: {0}")]
+    #[error(transparent)]
     Io(#[from] std::io::Error),
 
     /// Returned when the `type` field of a STAC object is not a [String].
@@ -48,11 +48,11 @@ pub enum Error {
 
     /// [reqwest::Error]
     #[cfg(feature = "reqwest")]
-    #[error("reqwest error: {0}")]
+    #[error(transparent)]
     Reqwest(#[from] reqwest::Error),
 
     /// [serde_json::Error]
-    #[error("serde_json error: {0}")]
+    #[error(transparent)]
     SerdeJson(#[from] serde_json::Error),
 
     /// [serde_urlencoded::ser::Error]
@@ -65,7 +65,7 @@ pub enum Error {
     UnknownType(String),
 
     /// [url::ParseError]
-    #[error("url parse error: {0}")]
+    #[error(transparent)]
     Url(#[from] url::ParseError),
 
     /// [jsonschema::ValidationError], but owned.


### PR DESCRIPTION
## Related to

- Replaces #121 

## Description

Adds `Link::set_query` behind a `set_query` feature.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
