### PR TITLE
feat: add url builder

### DIFF
--- a/stac-api/CHANGELOG.md
+++ b/stac-api/CHANGELOG.md
@@ -6,9 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-###
+### Added
 
 - `From<Vec<Collection>>` for `Collections` ([#124](https://github.com/gadomski/stac-rs/pull/124))
+- `UrlBuilder` ([#129](https://github.com/gadomski/stac-rs/pull/129))
 
 ## [0.1.0] - 2023-01-14
 

--- a/stac-api/src/builder.rs
+++ b/stac-api/src/builder.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Result};
+use crate::Error;
 use serde::Serialize;
 use stac::Link;
 use std::str::FromStr;
@@ -23,7 +23,112 @@ use url::{ParseError, Url};
 /// assert_eq!(link_builder.root().href, "http://stac-api-rs.test/api/v1/");
 /// ```
 #[derive(Debug)]
-pub struct LinkBuilder(Url);
+pub struct LinkBuilder(UrlBuilder);
+
+/// Builds urls on a root url.
+///
+/// # Examples
+///
+/// ```
+/// # use stac_api::UrlBuilder;
+/// let url_builder = UrlBuilder::new("http://stac-api-rs.test/api/v1").unwrap();
+/// assert_eq!(
+///     url_builder.items("my-great-collection").unwrap().as_str(),
+///     "http://stac-api-rs.test/api/v1/collections/my-great-collection/items"
+/// );
+/// ```
+#[derive(Debug)]
+pub struct UrlBuilder {
+    root: Url,
+    collections: Url,
+    collections_with_slash: Url,
+}
+
+impl UrlBuilder {
+    /// Creates a new url builder.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac_api::UrlBuilder;
+    /// let url_builder = UrlBuilder::new("http://stac-api-rs.test").unwrap();
+    /// ```
+    pub fn new(url: &str) -> Result<UrlBuilder, ParseError> {
+        let root: Url = if url.ends_with('/') {
+            url.parse()?
+        } else {
+            format!("{}/", url).parse()?
+        };
+        Ok(UrlBuilder {
+            collections: root.join("collections")?,
+            collections_with_slash: root.join("collections/")?,
+            root,
+        })
+    }
+
+    /// Returns the root url.
+    ///
+    /// The root url always has a trailing slash, even if the builder was
+    /// created without one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac_api::UrlBuilder;
+    /// let url_builder = UrlBuilder::new("http://stac-api-rs.test").unwrap();
+    /// assert_eq!(url_builder.root().as_str(), "http://stac-api-rs.test/");
+    /// ```
+    pub fn root(&self) -> &Url {
+        &self.root
+    }
+
+    /// Returns the collections url.
+    ///
+    /// This url is created when the builder is created, so it can't error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac_api::UrlBuilder;
+    /// let url_builder = UrlBuilder::new("http://stac-api-rs.test").unwrap();
+    /// assert_eq!(url_builder.collections().as_str(), "http://stac-api-rs.test/collections");
+    /// ```
+    pub fn collections(&self) -> &Url {
+        &self.collections
+    }
+
+    /// Returns a collection url.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac_api::UrlBuilder;
+    /// let url_builder = UrlBuilder::new("http://stac-api-rs.test").unwrap();
+    /// assert_eq!(
+    ///     url_builder.collection("a-collection").unwrap().as_str(),
+    ///     "http://stac-api-rs.test/collections/a-collection"
+    /// );
+    /// ```
+    pub fn collection(&self, id: &str) -> Result<Url, ParseError> {
+        self.collections_with_slash.join(id)
+    }
+
+    /// Returns an items url.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use stac_api::UrlBuilder;
+    /// let url_builder = UrlBuilder::new("http://stac-api-rs.test").unwrap();
+    /// assert_eq!(
+    ///     url_builder.items("a-collection").unwrap().as_str(),
+    ///     "http://stac-api-rs.test/collections/a-collection/items"
+    /// );
+    /// ```
+    pub fn items(&self, id: &str) -> Result<Url, ParseError> {
+        self.collections_with_slash.join(&format!("{}/items", id))
+    }
+}
 
 impl LinkBuilder {
     /// Returns a root link.
@@ -38,7 +143,7 @@ impl LinkBuilder {
     /// assert_eq!(root.href, "http://stac-api-rs.test/api/v1/");
     /// ```
     pub fn root(&self) -> Link {
-        Link::root(self.0.as_str())
+        Link::root(self.0.root())
     }
 
     /// Returns a root's self link.
@@ -53,7 +158,7 @@ impl LinkBuilder {
     /// assert_eq!(root.href, "http://stac-api-rs.test/api/v1/");
     /// ```
     pub fn root_self(&self) -> Link {
-        Link::self_(self.0.as_str())
+        Link::self_(self.0.root())
     }
 
     /// Returns an child link for a collection.
@@ -67,11 +172,8 @@ impl LinkBuilder {
     /// assert_eq!(link.rel, "child");
     /// assert_eq!(link.href, "http://stac-api-rs.test/api/v1/collections/an-id");
     /// ```
-    pub fn child_collection(&self, id: &str) -> Result<Link> {
-        self.0
-            .join(&format!("collections/{}", id))
-            .map(Link::child)
-            .map_err(Error::from)
+    pub fn child_collection(&self, id: &str) -> Result<Link, ParseError> {
+        self.0.collection(id).map(Link::child)
     }
 
     /// Returns a parent link for a collection.
@@ -88,7 +190,7 @@ impl LinkBuilder {
     /// assert_eq!(link.href, "http://stac-api-rs.test/api/v1/");
     /// ```
     pub fn collection_parent(&self) -> Link {
-        Link::parent(self.0.as_str())
+        Link::parent(self.0.root())
     }
 
     /// Returns a self link for a collection.
@@ -102,11 +204,8 @@ impl LinkBuilder {
     /// assert_eq!(link.rel, "self");
     /// assert_eq!(link.href, "http://stac-api-rs.test/api/v1/collections/an-id");
     /// ```
-    pub fn collection_self(&self, id: &str) -> Result<Link> {
-        self.0
-            .join(&format!("collections/{}", id))
-            .map(Link::self_)
-            .map_err(Error::from)
+    pub fn collection_self(&self, id: &str) -> Result<Link, ParseError> {
+        self.0.collection(id).map(Link::self_)
     }
 
     /// Returns an items link for a collection.
@@ -120,7 +219,7 @@ impl LinkBuilder {
     /// assert_eq!(link.rel, "items");
     /// assert_eq!(link.href, "http://stac-api-rs.test/api/v1/collections/an-id/items");
     /// ```
-    pub fn items<S>(&self, id: &str, parameters: S) -> Result<Link>
+    pub fn items<S>(&self, id: &str, parameters: S) -> Result<Link, Error>
     where
         S: Serialize,
     {
@@ -138,7 +237,7 @@ impl LinkBuilder {
     /// assert_eq!(link.rel, "next");
     /// assert_eq!(link.href, "http://stac-api-rs.test/api/v1/collections/an-id/items?foo=bar");
     /// ```
-    pub fn next_items<S>(&self, id: &str, parameters: S) -> Result<Link>
+    pub fn next_items<S>(&self, id: &str, parameters: S) -> Result<Link, Error>
     where
         S: Serialize,
     {
@@ -156,19 +255,19 @@ impl LinkBuilder {
     /// assert_eq!(link.rel, "prev");
     /// assert_eq!(link.href, "http://stac-api-rs.test/api/v1/collections/an-id/items?foo=bar");
     /// ```
-    pub fn prev_items<S>(&self, id: &str, parameters: S) -> Result<Link>
+    pub fn prev_items<S>(&self, id: &str, parameters: S) -> Result<Link, Error>
     where
         S: Serialize,
     {
         self.items_with_rel(id, parameters, "prev")
     }
 
-    fn items_with_rel<S>(&self, id: &str, parameters: S, rel: impl ToString) -> Result<Link>
+    fn items_with_rel<S>(&self, id: &str, parameters: S, rel: impl ToString) -> Result<Link, Error>
     where
         S: Serialize,
     {
         self.0
-            .join(&format!("collections/{}/items", id))
+            .items(id)
             .map_err(Error::from)
             .and_then(|url| {
                 serde_urlencoded::to_string(parameters)
@@ -177,10 +276,18 @@ impl LinkBuilder {
             })
             .map(|(mut url, query)| {
                 if !query.is_empty() {
-                    url.set_query(Some(&query));
+                    url.set_query(Some(&query))
                 }
                 Link::new(url, rel).geojson()
             })
+    }
+}
+
+impl FromStr for UrlBuilder {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        UrlBuilder::new(s)
     }
 }
 
@@ -188,10 +295,7 @@ impl FromStr for LinkBuilder {
     type Err = ParseError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        if s.ends_with('/') {
-            s.parse().map(LinkBuilder)
-        } else {
-            format!("{}/", s).parse().map(LinkBuilder)
-        }
+        s.parse::<UrlBuilder>()
+            .map(|url_builder| LinkBuilder(url_builder))
     }
 }

--- a/stac-api/src/lib.rs
+++ b/stac-api/src/lib.rs
@@ -47,28 +47,31 @@
 //! # use stac_api::LinkBuilder;
 //! # let link_builder: LinkBuilder = "http://stac-api-rs.test/api/v1".parse().unwrap();
 //! let link = link_builder.items("a-collection-id", [("limit", "10")]).unwrap();
-//! assert_eq!(link.href, "http://stac-api-rs.test/api/v1/collections/a-collection-id/items?limit=10");
+//! assert_eq!(
+//!     link.href,
+//!     "http://stac-api-rs.test/api/v1/collections/a-collection-id/items?limit=10"
+//! );
 //! ```
 
 #![deny(missing_docs, unused_extern_crates)]
 
+mod builder;
 mod collections;
 mod error;
 mod fields;
 mod item_collection;
 mod link;
-mod link_builder;
 mod root;
 mod search;
 mod sort;
 
 pub use {
+    builder::{LinkBuilder, UrlBuilder},
     collections::Collections,
     error::Error,
     fields::Fields,
     item_collection::{Context, ItemCollection},
     link::Link,
-    link_builder::LinkBuilder,
     root::Root,
     search::Search,
     sort::Sortby,


### PR DESCRIPTION
## Description

Breaks out the url construction to its own builder, which will be used (e.g.) for an async API client.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
