### PR TITLE
Implement `Deserialize` for `Value`

### DIFF
--- a/stac-async/CHANGELOG.md
+++ b/stac-async/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Refactored to modules ([#130](https://github.com/gadomski/stac-rs/pull/130))
+- `stac_async::read` now can return anything that deserializes and implements `Href` ([#135](https://github.com/gadomski/stac-rs/pull/135))
 
 ## [0.3.0] - 2023-01-08
 

--- a/stac-async/src/lib.rs
+++ b/stac-async/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ```
 //! # tokio_test::block_on(async {
-//! let value = stac_async::read("data/simple-item.json").await.unwrap();
+//! let item: stac::Item = stac_async::read("data/simple-item.json").await.unwrap();
 //! # })
 //! ```
 

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - STAC API fields to `Link` ([#126](https://github.com/gadomski/stac-rs/pull/126)])
 - `TryFrom<Value>` (and `TryFrom<Item>` and friends) for a `serde_json::Map<String, serde_json::Value>` ([#126](https://github.com/gadomski/stac-rs/pull/126), [#130](https://github.com/gadomski/stac-rs/pull/130))
+- `Deserialize` for `Value` ([#135](https://github.com/gadomski/stac-rs/pull/135))
+
+### Changed
+
+- `stac::read` now can return anything that deserializes and implements `Href` ([#135](https://github.com/gadomski/stac-rs/pull/135))
 
 ## [0.3.1] - 2023-01-13
 

--- a/stac/README.md
+++ b/stac/README.md
@@ -60,8 +60,7 @@ stac = { version = "0.3", features = ["set_query"]}
 let item = stac::Item::new("an-id");
 
 // Read an item from the filesystem.
-let value = stac::read("data/simple-item.json").unwrap();
-let item: stac::Item = value.try_into().unwrap();
+let item: stac::Item = stac::read("data/simple-item.json").unwrap();
 ```
 
 Please see the [documentation](https://docs.rs/stac) for more usage examples.

--- a/stac/examples/validate.rs
+++ b/stac/examples/validate.rs
@@ -1,4 +1,4 @@
-use stac::{Error, Validate};
+use stac::{Error, Validate, Value};
 
 fn main() {
     let args: Vec<_> = std::env::args().collect();
@@ -12,7 +12,7 @@ fn main() {
         );
         std::process::exit(1)
     }
-    let value = stac::read(&args[1]).unwrap();
+    let value: Value = stac::read(&args[1]).unwrap();
     match value.validate() {
         Ok(()) => println!("OK: {} is valid STAC!", args[1]),
         Err(errors) => {

--- a/stac/src/href.rs
+++ b/stac/src/href.rs
@@ -9,7 +9,7 @@
 /// use stac::{Item, Href};
 /// let item = Item::new("an-id");
 /// assert!(item.href().is_none());
-/// let item = stac::read("data/simple-item.json").unwrap();
+/// let item: Item = stac::read("data/simple-item.json").unwrap();
 /// assert!(item.href().is_some());
 /// ```
 pub trait Href {

--- a/stac/src/item.rs
+++ b/stac/src/item.rs
@@ -179,7 +179,7 @@ impl Item {
     ///
     /// ```
     /// use stac::Item;
-    /// let item: Item = stac::read("data/simple-item.json").unwrap().try_into().unwrap();
+    /// let item: Item = stac::read("data/simple-item.json").unwrap();
     /// let link = item.collection_link().unwrap();
     /// ```
     pub fn collection_link(&self) -> Option<&Link> {

--- a/stac/src/lib.rs
+++ b/stac/src/lib.rs
@@ -42,13 +42,10 @@
 //!
 //! # Reading
 //!
-//! Synchronous reads from the filesystem are supported via [read].
-//! Read objects are returned as a [Value], which implements [TryInto] for all three object types:
+//! Synchronous reads from the filesystem are supported via [read]:
 //!
 //! ```
-//! let value = stac::read("data/simple-item.json").unwrap();
-//! assert!(value.is_item());
-//! let item: stac::Item = value.try_into().unwrap();
+//! let value: stac::Item = stac::read("data/simple-item.json").unwrap();
 //! ```
 //!
 //! If the [reqwest](https://docs.rs/reqwest/latest/reqwest/) feature is enabled, synchronous reads from urls are also supported:
@@ -57,7 +54,7 @@
 //! #[cfg(feature = "reqwest")]
 //! {
 //!     let url = "https://raw.githubusercontent.com/radiantearth/stac-spec/master/examples/simple-item.json";
-//!     let value = stac::read(url).unwrap();
+//!     let item: stac::Item = stac::read(url).unwrap();
 //! }
 //! ```
 //!
@@ -67,7 +64,7 @@
 //! #[cfg(not(feature = "reqwest"))]
 //! {
 //!     let url = "https://raw.githubusercontent.com/radiantearth/stac-spec/master/examples/simple-item.json";
-//!     let error = stac::read(url).unwrap_err();
+//!     let error = stac::read::<stac::Item>(url).unwrap_err();
 //! }
 //! ```
 //!
@@ -78,10 +75,8 @@
 //!
 //! ```
 //! use stac::{Href, Item};
-//! let value = stac::read("data/simple-item.json").unwrap();
-//! assert!(value.href().as_deref().unwrap().ends_with("data/simple-item.json"));
-//! let item: Item = value.clone().try_into().unwrap();
-//! assert_eq!(value.href(), item.href());
+//! let item: Item = stac::read("data/simple-item.json").unwrap();
+//! assert!(item.href().as_deref().unwrap().ends_with("data/simple-item.json"));
 //! ```
 //!
 //! # Validation

--- a/stac/src/link.rs
+++ b/stac/src/link.rs
@@ -96,7 +96,7 @@ pub trait Links {
     ///
     /// ```
     /// use stac::Links;
-    /// let item = stac::read("data/simple-item.json").unwrap();
+    /// let item: stac::Item = stac::read("data/simple-item.json").unwrap();
     /// let links = item.links();
     /// ```
     fn links(&self) -> &[Link];
@@ -109,7 +109,7 @@ pub trait Links {
     ///
     /// ```
     /// use stac::Links;
-    /// let mut item = stac::read("data/simple-item.json").unwrap();
+    /// let mut item: stac::Item = stac::read("data/simple-item.json").unwrap();
     /// let links = item.links_mut();
     /// links.clear();
     /// ```
@@ -121,7 +121,7 @@ pub trait Links {
     ///
     /// ```
     /// use stac::Links;
-    /// let item = stac::read("data/simple-item.json").unwrap();
+    /// let item: stac::Item = stac::read("data/simple-item.json").unwrap();
     /// let link = item.link("root").unwrap();
     /// ```
     fn link(&self, rel: &str) -> Option<&Link> {
@@ -137,7 +137,7 @@ pub trait Links {
     ///
     /// ```
     /// use stac::{Links, Link};
-    /// let mut item = stac::read("data/simple-item.json").unwrap();
+    /// let mut item: stac::Item = stac::read("data/simple-item.json").unwrap();
     /// item.set_link(Link::root("a/href"));
     /// ```
     fn set_link(&mut self, link: Link) {
@@ -153,7 +153,7 @@ pub trait Links {
     ///
     /// ```
     /// use stac::Links;
-    /// let item = stac::read("data/simple-item.json").unwrap();
+    /// let item: stac::Item = stac::read("data/simple-item.json").unwrap();
     /// let link = item.root_link().unwrap();
     /// ```
     fn root_link(&self) -> Option<&Link> {
@@ -168,7 +168,7 @@ pub trait Links {
     ///
     /// ```
     /// use stac::Links;
-    /// let item = stac::read("data/simple-item.json").unwrap();
+    /// let item: stac::Item = stac::read("data/simple-item.json").unwrap();
     /// let link = item.root_link().unwrap();
     /// ```
     fn self_link(&self) -> Option<&Link> {
@@ -183,7 +183,7 @@ pub trait Links {
     ///
     /// ```
     /// use stac::Links;
-    /// let item = stac::read("data/simple-item.json").unwrap();
+    /// let item: stac::Item = stac::read("data/simple-item.json").unwrap();
     /// let link = item.parent_link().unwrap();
     /// ```
     fn parent_link(&self) -> Option<&Link> {
@@ -196,7 +196,7 @@ pub trait Links {
     ///
     /// ```
     /// use stac::Links;
-    /// let collection = stac::read("data/collection.json").unwrap();
+    /// let collection: stac::Collection = stac::read("data/collection.json").unwrap();
     /// let links: Vec<_> = collection.iter_child_links().collect();
     /// ```
     fn iter_child_links(&self) -> Box<dyn Iterator<Item = &Link> + '_> {
@@ -209,7 +209,7 @@ pub trait Links {
     ///
     /// ```
     /// use stac::Links;
-    /// let collection = stac::read("data/collection.json").unwrap();
+    /// let collection: stac::Collection = stac::read("data/collection.json").unwrap();
     /// let links: Vec<_> = collection.iter_item_links().collect();
     /// ```
     fn iter_item_links(&self) -> Box<dyn Iterator<Item = &Link> + '_> {
@@ -223,7 +223,7 @@ pub trait Links {
     /// ```
     /// use stac::{Links, Catalog, Error, Href};
     ///
-    /// let mut catalog = stac::read("data/catalog.json").unwrap();
+    /// let mut catalog: stac::Catalog = stac::read("data/catalog.json").unwrap();
     /// assert!(!catalog.root_link().unwrap().is_absolute());
     /// catalog.make_relative_links_absolute("data/catalog.json").unwrap();
     /// assert!(catalog.root_link().unwrap().is_absolute());
@@ -660,7 +660,7 @@ mod tests {
     }
 
     mod links {
-        use crate::{Item, Link, Links};
+        use crate::{Catalog, Item, Link, Links};
 
         #[test]
         fn link() {
@@ -688,7 +688,7 @@ mod tests {
 
         #[test]
         fn make_relative_links_absolute_path() {
-            let mut catalog = crate::read("data/catalog.json").unwrap();
+            let mut catalog: Catalog = crate::read("data/catalog.json").unwrap();
             catalog
                 .make_relative_links_absolute("data/catalog.json")
                 .unwrap();
@@ -699,7 +699,7 @@ mod tests {
 
         #[test]
         fn make_relative_links_absolute_url() {
-            let mut catalog = crate::read("data/catalog.json").unwrap();
+            let mut catalog: Catalog = crate::read("data/catalog.json").unwrap();
             catalog
                 .make_relative_links_absolute("http://stac-rs.test/catalog.json")
                 .unwrap();

--- a/stac/src/validate.rs
+++ b/stac/src/validate.rs
@@ -16,8 +16,8 @@
 //!
 //! ```
 //! use stac::Validate;
-//! stac::read("data/simple-item.json").unwrap().validate().unwrap();
-//! let errors = stac::read("examples/invalid-item.json").unwrap().validate().unwrap_err();
+//! stac::read::<stac::Item>("data/simple-item.json").unwrap().validate().unwrap();
+//! let errors = stac::read::<stac::Item>("examples/invalid-item.json").unwrap().validate().unwrap_err();
 //! for error in errors {
 //!     println!("ERROR: {}", error);
 //! }
@@ -26,12 +26,12 @@
 //! If you're doing multiple validations, it is more efficient to use the [Validator] structure, which will cache any fetched schemas, including extension schemas:
 //!
 //! ```
-//! use stac::Validator;
+//! use stac::{Validator, Item, Catalog};
 //! let mut validator = Validator::new().unwrap();
-//! let item = stac::read("data/simple-item.json").unwrap();
-//! let catalog = stac::read("data/catalog.json").unwrap();
-//! validator.validate(item).unwrap();
-//! validator.validate(catalog).unwrap();
+//! let item: Item = stac::read("data/simple-item.json").unwrap();
+//! let catalog: Catalog = stac::read("data/catalog.json").unwrap();
+//! validator.validate_item(item).unwrap();
+//! validator.validate_catalog(catalog).unwrap();
 //! ```
 
 use crate::{Catalog, Collection, Error, Extensions, Item, ItemCollection, Value};
@@ -164,12 +164,12 @@ impl Validator {
     /// # Examples
     ///
     /// ```
-    /// # use stac::{Value, Validator};
+    /// # use stac::{Item, Value, Validator};
     /// let mut validator = Validator::new().unwrap();
-    /// let item = stac::read("data/simple-item.json").unwrap();
-    /// validator.validate(item).unwrap();
+    /// let item: stac::Value = stac::read("data/simple-item.json").unwrap();
+    /// validator.validate_value(item).unwrap();
     /// ```
-    pub fn validate(&mut self, value: Value) -> Result<(), Vec<Error>> {
+    pub fn validate_value(&mut self, value: Value) -> Result<(), Vec<Error>> {
         match value {
             Value::Item(item) => self.validate_item(item),
             Value::Catalog(catalog) => self.validate_catalog(catalog),
@@ -296,7 +296,7 @@ fn into_error(validation_error: ValidationError<'_>) -> Error {
 #[cfg(test)]
 mod tests {
     use super::Validate;
-    use crate::{Catalog, Collection, Item};
+    use crate::{Catalog, Collection, Item, ItemCollection};
 
     #[test]
     fn valid_item() {
@@ -371,7 +371,7 @@ mod tests {
 
     #[test]
     fn item_collection() {
-        let item_collection = crate::read("examples/item-collection.json").unwrap();
+        let item_collection: ItemCollection = crate::read("examples/item-collection.json").unwrap();
         item_collection.validate().unwrap();
     }
 }


### PR DESCRIPTION
## Description

Previously, we had a `from_json` method -- this PR moves that logic down into deserialize itself, making our read interfaces a bit cleaner. This is breaking, since previously we always returned a `Value` -- now we can go straight to an `Item` from `stac::read`, if we want.

We couldn't use tagged enums b/c the tag deserialization strips the field, and we need it on the underlying data structure.

We also implemented the same interface for **stac-async**.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
