### PR TITLE
Deserialize with

### DIFF
--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - STAC API fields to `Link` ([#126](https://github.com/gadomski/stac-rs/pull/126)])
 - `TryFrom<Value>` (and `TryFrom<Item>` and friends) for a `serde_json::Map<String, serde_json::Value>` ([#126](https://github.com/gadomski/stac-rs/pull/126), [#130](https://github.com/gadomski/stac-rs/pull/130))
 - `Deserialize` for `Value` ([#135](https://github.com/gadomski/stac-rs/pull/135))
+- `type` checks on (de)serialization ([#136](https://github.com/gadomski/stac-rs/pull/136))
 
 ### Changed
 

--- a/stac/src/catalog.rs
+++ b/stac/src/catalog.rs
@@ -20,6 +20,10 @@ pub const CATALOG_TYPE: &str = "Catalog";
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Catalog {
     /// Set to `"Catalog"` if this Catalog only implements the `Catalog` spec.
+    #[serde(
+        deserialize_with = "deserialize_type",
+        serialize_with = "serialize_type"
+    )]
     pub r#type: String,
 
     /// The STAC version the `Catalog` implements.
@@ -97,6 +101,20 @@ impl Links for Catalog {
     fn links_mut(&mut self) -> &mut Vec<Link> {
         &mut self.links
     }
+}
+
+fn deserialize_type<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    crate::deserialize_type(deserializer, CATALOG_TYPE)
+}
+
+fn serialize_type<S>(r#type: &String, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::ser::Serializer,
+{
+    crate::serialize_type(r#type, serializer, CATALOG_TYPE)
 }
 
 #[cfg(test)]

--- a/stac/src/catalog.rs
+++ b/stac/src/catalog.rs
@@ -1,4 +1,4 @@
-use crate::{Href, Link, Links, STAC_VERSION};
+use crate::{Error, Href, Link, Links, Result, STAC_VERSION};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
@@ -103,14 +103,25 @@ impl Links for Catalog {
     }
 }
 
-fn deserialize_type<'de, D>(deserializer: D) -> Result<String, D::Error>
+impl TryFrom<Catalog> for Map<String, Value> {
+    type Error = Error;
+    fn try_from(catalog: Catalog) -> Result<Self> {
+        if let serde_json::Value::Object(object) = serde_json::to_value(catalog)? {
+            Ok(object)
+        } else {
+            panic!("all STAC catalogs should serialize to a serde_json::Value::Object")
+        }
+    }
+}
+
+fn deserialize_type<'de, D>(deserializer: D) -> std::result::Result<String, D::Error>
 where
     D: serde::de::Deserializer<'de>,
 {
     crate::deserialize_type(deserializer, CATALOG_TYPE)
 }
 
-fn serialize_type<S>(r#type: &String, serializer: S) -> Result<S::Ok, S::Error>
+fn serialize_type<S>(r#type: &String, serializer: S) -> std::result::Result<S::Ok, S::Error>
 where
     S: serde::ser::Serializer,
 {

--- a/stac/src/collection.rs
+++ b/stac/src/collection.rs
@@ -23,6 +23,10 @@ const DEFAULT_LICENSE: &str = "proprietary";
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Collection {
     /// Must be set to `"Collection"` to be a valid `Collection`.
+    #[serde(
+        deserialize_with = "deserialize_type",
+        serialize_with = "serialize_type"
+    )]
     pub r#type: String,
 
     /// The STAC version the `Collection` implements.
@@ -233,6 +237,20 @@ impl Default for TemporalExtent {
             interval: vec![[None, None]],
         }
     }
+}
+
+fn deserialize_type<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    crate::deserialize_type(deserializer, COLLECTION_TYPE)
+}
+
+fn serialize_type<S>(r#type: &String, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::ser::Serializer,
+{
+    crate::serialize_type(r#type, serializer, COLLECTION_TYPE)
 }
 
 #[cfg(test)]

--- a/stac/src/collection.rs
+++ b/stac/src/collection.rs
@@ -1,4 +1,4 @@
-use crate::{Asset, Href, Link, Links, STAC_VERSION};
+use crate::{Asset, Error, Href, Link, Links, Result, STAC_VERSION};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::collections::HashMap;
@@ -239,14 +239,25 @@ impl Default for TemporalExtent {
     }
 }
 
-fn deserialize_type<'de, D>(deserializer: D) -> Result<String, D::Error>
+impl TryFrom<Collection> for Map<String, Value> {
+    type Error = Error;
+    fn try_from(collection: Collection) -> Result<Self> {
+        if let serde_json::Value::Object(object) = serde_json::to_value(collection)? {
+            Ok(object)
+        } else {
+            panic!("all STAC collections should serialize to a serde_json::Value::Object")
+        }
+    }
+}
+
+fn deserialize_type<'de, D>(deserializer: D) -> std::result::Result<String, D::Error>
 where
     D: serde::de::Deserializer<'de>,
 {
     crate::deserialize_type(deserializer, COLLECTION_TYPE)
 }
 
-fn serialize_type<S>(r#type: &String, serializer: S) -> Result<S::Ok, S::Error>
+fn serialize_type<S>(r#type: &String, serializer: S) -> std::result::Result<S::Ok, S::Error>
 where
     S: serde::ser::Serializer,
 {

--- a/stac/src/item.rs
+++ b/stac/src/item.rs
@@ -1,4 +1,4 @@
-use crate::{Asset, Href, Link, Links, STAC_VERSION};
+use crate::{Asset, Error, Href, Link, Links, Result, STAC_VERSION};
 use chrono::Utc;
 use geojson::Geometry;
 use serde::{Deserialize, Serialize};
@@ -183,14 +183,25 @@ impl Links for Item {
     }
 }
 
-fn deserialize_type<'de, D>(deserializer: D) -> Result<String, D::Error>
+impl TryFrom<Item> for Map<String, Value> {
+    type Error = Error;
+    fn try_from(item: Item) -> Result<Self> {
+        if let serde_json::Value::Object(object) = serde_json::to_value(item)? {
+            Ok(object)
+        } else {
+            panic!("all STAC items should serialize to a serde_json::Value::Object")
+        }
+    }
+}
+
+fn deserialize_type<'de, D>(deserializer: D) -> std::result::Result<String, D::Error>
 where
     D: serde::de::Deserializer<'de>,
 {
     crate::deserialize_type(deserializer, ITEM_TYPE)
 }
 
-fn serialize_type<S>(r#type: &String, serializer: S) -> Result<S::Ok, S::Error>
+fn serialize_type<S>(r#type: &String, serializer: S) -> std::result::Result<S::Ok, S::Error>
 where
     S: serde::ser::Serializer,
 {

--- a/stac/src/item_collection.rs
+++ b/stac/src/item_collection.rs
@@ -1,0 +1,95 @@
+use crate::{Href, Item, Link, Links};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// The type field for [ItemCollections](ItemCollection).
+pub const ITEM_COLLECTION_TYPE: &str = "FeatureCollection";
+
+/// A [GeoJSON FeatureCollection](https://www.rfc-editor.org/rfc/rfc7946#page-12) of items.
+///
+/// While not part of the STAC specification, ItemCollections are often used to store many items in a single file.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct ItemCollection {
+    /// The type field.
+    ///
+    /// Must be set to "FeatureCollection".
+    #[serde(
+        deserialize_with = "deserialize_type",
+        serialize_with = "serialize_type"
+    )]
+    pub r#type: String,
+
+    /// The list of [Items](Item).
+    ///
+    /// The attribute is actually "features", but we rename to "items".
+    #[serde(rename = "features")]
+    pub items: Vec<Item>,
+
+    /// List of link objects to resources and related URLs.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub links: Vec<Link>,
+
+    /// Additional fields.
+    #[serde(flatten)]
+    pub additional_fields: Map<String, Value>,
+
+    #[serde(skip)]
+    href: Option<String>,
+}
+
+impl From<Vec<Item>> for ItemCollection {
+    fn from(items: Vec<Item>) -> Self {
+        ItemCollection {
+            r#type: ITEM_COLLECTION_TYPE.to_string(),
+            items: items,
+            links: Vec::new(),
+            additional_fields: Map::new(),
+            href: None,
+        }
+    }
+}
+
+impl Href for ItemCollection {
+    fn href(&self) -> Option<&str> {
+        self.href.as_deref()
+    }
+
+    fn set_href(&mut self, href: impl ToString) {
+        self.href = Some(href.to_string())
+    }
+}
+
+impl Links for ItemCollection {
+    fn links(&self) -> &[Link] {
+        &self.links
+    }
+    fn links_mut(&mut self) -> &mut Vec<Link> {
+        &mut self.links
+    }
+}
+
+fn deserialize_type<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    crate::deserialize_type(deserializer, ITEM_COLLECTION_TYPE)
+}
+
+fn serialize_type<S>(r#type: &String, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::ser::Serializer,
+{
+    crate::serialize_type(r#type, serializer, ITEM_COLLECTION_TYPE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ItemCollection;
+    use crate::Item;
+
+    #[test]
+    fn item_collection_from_vec() {
+        let items = vec![Item::new("a"), Item::new("b")];
+        let _ = ItemCollection::from(items);
+    }
+}


### PR DESCRIPTION
## Related to

- Improves on serialization changes in #135 

## Description

After thinking about it, I realized I could push the serialize/deserialize checks to the items themselves, and then just use untagged for `Value`. Much nicer.

Includes some movement of where stuff is defined, and removes some now-useless conversion methods. Probably breaking, but we're already committed to a major so not stressing about it.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
