### PR TITLE
Add assets trait

### DIFF
--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -12,10 +12,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `TryFrom<Value>` (and `TryFrom<Item>` and friends) for a `serde_json::Map<String, serde_json::Value>` ([#126](https://github.com/gadomski/stac-rs/pull/126), [#130](https://github.com/gadomski/stac-rs/pull/130))
 - `Deserialize` for `Value` ([#135](https://github.com/gadomski/stac-rs/pull/135))
 - `type` checks on (de)serialization ([#136](https://github.com/gadomski/stac-rs/pull/136))
+- `Assets` trait ([#137](https://github.com/gadomski/stac-rs/pull/137))
 
 ### Changed
 
 - `stac::read` now can return anything that deserializes and implements `Href` ([#135](https://github.com/gadomski/stac-rs/pull/135))
+- `Collection::assets` is now non-optional ([#137](https://github.com/gadomski/stac-rs/pull/137))
 
 ## [0.3.1] - 2023-01-13
 

--- a/stac/src/asset.rs
+++ b/stac/src/asset.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use std::collections::HashMap;
 
 /// An Asset is an object that contains a URI to data associated with the [Item](crate::Item) that can be downloaded or streamed.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -32,6 +33,37 @@ pub struct Asset {
     /// Additional fields on the asset.
     #[serde(flatten)]
     pub additional_fields: Map<String, Value>,
+}
+
+/// Trait implemented by anything that has assets.
+///
+/// As of STAC v1.0.0, this is [Collection](crate::Collection) and [Item](crate::Item).
+pub trait Assets {
+    /// Returns a reference to this object's assets.
+    ///
+    /// # Examples
+    ///
+    /// [Item](crate::Item) has assets:
+    ///
+    /// ```
+    /// use stac::{Item, Assets};
+    /// let item: Item = stac::read("data/simple-item.json").unwrap();
+    /// assert!(!item.assets().is_empty());
+    /// ```
+    fn assets(&self) -> &HashMap<String, Asset>;
+
+    /// Returns a mut reference to this object's assets.
+    ///
+    /// # Examples
+    ///
+    /// [Item](crate::Item) has assets:
+    ///
+    /// ```
+    /// use stac::{Item, Asset, Assets};
+    /// let mut item: Item = stac::read("data/simple-item.json").unwrap();
+    /// item.assets_mut().insert("foo".to_string(), Asset::new("./asset.tif"));
+    /// ```
+    fn assets_mut(&mut self) -> &mut HashMap<String, Asset>;
 }
 
 impl Asset {

--- a/stac/src/catalog.rs
+++ b/stac/src/catalog.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Href, Link, Links, Result, STAC_VERSION};
+use crate::{Error, Extensions, Href, Link, Links, Result, STAC_VERSION};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
@@ -111,6 +111,12 @@ impl TryFrom<Catalog> for Map<String, Value> {
         } else {
             panic!("all STAC catalogs should serialize to a serde_json::Value::Object")
         }
+    }
+}
+
+impl Extensions for Catalog {
+    fn extensions(&self) -> Option<&[String]> {
+        self.extensions.as_deref()
     }
 }
 

--- a/stac/src/collection.rs
+++ b/stac/src/collection.rs
@@ -1,4 +1,4 @@
-use crate::{Asset, Error, Href, Link, Links, Result, STAC_VERSION};
+use crate::{Asset, Assets, Error, Extensions, Href, Link, Links, Result, STAC_VERSION};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::collections::HashMap;
@@ -79,8 +79,8 @@ pub struct Collection {
     pub links: Vec<Link>,
 
     /// Dictionary of asset objects that can be downloaded, each with a unique key.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub assets: Option<HashMap<String, Asset>>,
+    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
+    pub assets: HashMap<String, Asset>,
 
     /// Additional fields not part of the `Collection` specification.
     #[serde(flatten)]
@@ -176,7 +176,7 @@ impl Collection {
             extent: Extent::default(),
             summaries: None,
             links: Vec::new(),
-            assets: None,
+            assets: HashMap::new(),
             additional_fields: Map::new(),
             href: None,
         }
@@ -239,6 +239,21 @@ impl Default for TemporalExtent {
     }
 }
 
+impl Assets for Collection {
+    fn assets(&self) -> &HashMap<String, Asset> {
+        &self.assets
+    }
+    fn assets_mut(&mut self) -> &mut HashMap<String, Asset> {
+        &mut self.assets
+    }
+}
+
+impl Extensions for Collection {
+    fn extensions(&self) -> Option<&[String]> {
+        self.extensions.as_deref()
+    }
+}
+
 impl TryFrom<Collection> for Map<String, Value> {
     type Error = Error;
     fn try_from(collection: Collection) -> Result<Self> {
@@ -281,7 +296,7 @@ mod tests {
             assert!(collection.providers.is_none());
             assert_eq!(collection.extent, Extent::default());
             assert!(collection.summaries.is_none());
-            assert!(collection.assets.is_none());
+            assert!(collection.assets.is_empty());
             assert_eq!(collection.r#type, "Collection");
             assert_eq!(collection.version, STAC_VERSION);
             assert!(collection.extensions.is_none());

--- a/stac/src/extensions.rs
+++ b/stac/src/extensions.rs
@@ -1,5 +1,3 @@
-use crate::{Catalog, Collection, Item};
-
 /// A trait for objects that may have STAC extensions.
 pub trait Extensions {
     /// Returns a reference to this object's extensions.
@@ -12,21 +10,4 @@ pub trait Extensions {
     /// assert!(item.extensions().is_none());
     /// ```
     fn extensions(&self) -> Option<&[String]>;
-}
-
-impl Extensions for Item {
-    fn extensions(&self) -> Option<&[String]> {
-        self.extensions.as_deref()
-    }
-}
-impl Extensions for Catalog {
-    fn extensions(&self) -> Option<&[String]> {
-        self.extensions.as_deref()
-    }
-}
-
-impl Extensions for Collection {
-    fn extensions(&self) -> Option<&[String]> {
-        self.extensions.as_deref()
-    }
 }

--- a/stac/src/item.rs
+++ b/stac/src/item.rs
@@ -1,4 +1,4 @@
-use crate::{Asset, Error, Href, Link, Links, Result, STAC_VERSION};
+use crate::{Asset, Assets, Error, Extensions, Href, Link, Links, Result, STAC_VERSION};
 use chrono::Utc;
 use geojson::Geometry;
 use serde::{Deserialize, Serialize};
@@ -180,6 +180,21 @@ impl Links for Item {
     }
     fn links_mut(&mut self) -> &mut Vec<Link> {
         &mut self.links
+    }
+}
+
+impl Assets for Item {
+    fn assets(&self) -> &HashMap<String, Asset> {
+        &self.assets
+    }
+    fn assets_mut(&mut self) -> &mut HashMap<String, Asset> {
+        &mut self.assets
+    }
+}
+
+impl Extensions for Item {
+    fn extensions(&self) -> Option<&[String]> {
+        self.extensions.as_deref()
     }
 }
 

--- a/stac/src/lib.rs
+++ b/stac/src/lib.rs
@@ -143,7 +143,7 @@ mod value;
 #[cfg(feature = "jsonschema")]
 pub use validate::{Validate, Validator};
 pub use {
-    asset::Asset,
+    asset::{Asset, Assets},
     catalog::{Catalog, CATALOG_TYPE},
     collection::{Collection, Extent, Provider, SpatialExtent, TemporalExtent, COLLECTION_TYPE},
     error::Error,


### PR DESCRIPTION
## Related to

- I'll use this for #134, because I'll want to generalize the behavior over anything that has assets

## Description

Adds an assets trait. Also changes `Collection::assets` to non-optional (breaking api change but we're committed).

## Checklist

Delete any checklist items that do not apply (e.g. if your change is minor, it may not require documentation updates).

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
