### PR TITLE
Release v0.3.2

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,3 +1,3 @@
-allow-branch = ["main"]
+allow-branch = ["main", "release/*"]
 enable-all-features = true
 sign-tag = true

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.3.2] - 2023-02-19
+
 ### Added
 
 - STAC API fields to `Link` ([#126](https://github.com/gadomski/stac-rs/pull/126)])

--- a/stac/Cargo.toml
+++ b/stac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stac"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Pete Gadomski <pete.gadomski@gmail.com>"]
 edition = "2021"
 description = "Rust library for the SpatioTemporal Asset Catalog (STAC) specification"


### PR DESCRIPTION
## Description

Last release of the v0.3 line before the breaking changes from #135.

https://crates.io/crates/stac/0.3.2

## Checklist

- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
