### PR TITLE
Make the type and version fields private

### DIFF
--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - `stac::read` now can return anything that deserializes and implements `Href` ([#135](https://github.com/gadomski/stac-rs/pull/135))
 - `Collection::assets` is now non-optional ([#137](https://github.com/gadomski/stac-rs/pull/137))
+- `type` and `version` fields on all objects are now private ([#141](https://github.com/gadomski/stac-rs/pull/141))
 
 ## [0.3.2] - 2023-02-19
 

--- a/stac/src/catalog.rs
+++ b/stac/src/catalog.rs
@@ -19,17 +19,6 @@ pub const CATALOG_TYPE: &str = "Catalog";
 /// to build a searchable index.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Catalog {
-    /// Set to `"Catalog"` if this Catalog only implements the `Catalog` spec.
-    #[serde(
-        deserialize_with = "deserialize_type",
-        serialize_with = "serialize_type"
-    )]
-    pub r#type: String,
-
-    /// The STAC version the `Catalog` implements.
-    #[serde(rename = "stac_version")]
-    pub version: String,
-
     /// A list of extension identifiers the `Catalog` implements.
     #[serde(rename = "stac_extensions")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -53,6 +42,17 @@ pub struct Catalog {
     /// Additional fields not part of the Catalog specification.
     #[serde(flatten)]
     pub additional_fields: Map<String, Value>,
+
+    /// Set to `"Catalog"` if this Catalog only implements the `Catalog` spec.
+    #[serde(
+        deserialize_with = "deserialize_type",
+        serialize_with = "serialize_type"
+    )]
+    r#type: String,
+
+    /// The STAC version the `Catalog` implements.
+    #[serde(rename = "stac_version")]
+    version: String,
 
     #[serde(skip)]
     href: Option<String>,

--- a/stac/src/collection.rs
+++ b/stac/src/collection.rs
@@ -22,17 +22,6 @@ const DEFAULT_LICENSE: &str = "proprietary";
 /// STAC `Catalog`.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Collection {
-    /// Must be set to `"Collection"` to be a valid `Collection`.
-    #[serde(
-        deserialize_with = "deserialize_type",
-        serialize_with = "serialize_type"
-    )]
-    pub r#type: String,
-
-    /// The STAC version the `Collection` implements.
-    #[serde(rename = "stac_version")]
-    pub version: String,
-
     /// A list of extension identifiers the `Collection` implements.
     #[serde(rename = "stac_extensions")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -85,6 +74,17 @@ pub struct Collection {
     /// Additional fields not part of the `Collection` specification.
     #[serde(flatten)]
     pub additional_fields: Map<String, Value>,
+
+    /// Must be set to `"Collection"` to be a valid `Collection`.
+    #[serde(
+        deserialize_with = "deserialize_type",
+        serialize_with = "serialize_type"
+    )]
+    r#type: String,
+
+    /// The STAC version the `Collection` implements.
+    #[serde(rename = "stac_version")]
+    version: String,
 
     #[serde(skip)]
     href: Option<String>,

--- a/stac/src/item.rs
+++ b/stac/src/item.rs
@@ -17,17 +17,6 @@ pub const ITEM_TYPE: &str = "Feature";
 /// (e.g., satellite imagery, derived data, DEMs).
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Item {
-    /// Type of the GeoJSON Object. MUST be set to `"Feature"`.
-    #[serde(
-        deserialize_with = "deserialize_type",
-        serialize_with = "serialize_type"
-    )]
-    pub r#type: String,
-
-    /// The STAC version the `Item` implements.
-    #[serde(rename = "stac_version")]
-    pub version: String,
-
     /// A list of extensions the `Item` implements.
     #[serde(rename = "stac_extensions")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -77,6 +66,17 @@ pub struct Item {
     /// Additional fields not part of the Item specification.
     #[serde(flatten)]
     pub additional_fields: Map<String, Value>,
+
+    /// Type of the GeoJSON Object. MUST be set to `"Feature"`.
+    #[serde(
+        deserialize_with = "deserialize_type",
+        serialize_with = "serialize_type"
+    )]
+    r#type: String,
+
+    /// The STAC version the `Item` implements.
+    #[serde(rename = "stac_version")]
+    version: String,
 
     #[serde(skip)]
     href: Option<String>,

--- a/stac/src/item_collection.rs
+++ b/stac/src/item_collection.rs
@@ -10,15 +10,6 @@ pub const ITEM_COLLECTION_TYPE: &str = "FeatureCollection";
 /// While not part of the STAC specification, ItemCollections are often used to store many items in a single file.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct ItemCollection {
-    /// The type field.
-    ///
-    /// Must be set to "FeatureCollection".
-    #[serde(
-        deserialize_with = "deserialize_type",
-        serialize_with = "serialize_type"
-    )]
-    pub r#type: String,
-
     /// The list of [Items](Item).
     ///
     /// The attribute is actually "features", but we rename to "items".
@@ -32,6 +23,15 @@ pub struct ItemCollection {
     /// Additional fields.
     #[serde(flatten)]
     pub additional_fields: Map<String, Value>,
+
+    /// The type field.
+    ///
+    /// Must be set to "FeatureCollection".
+    #[serde(
+        deserialize_with = "deserialize_type",
+        serialize_with = "serialize_type"
+    )]
+    r#type: String,
 
     #[serde(skip)]
     href: Option<String>,


### PR DESCRIPTION
## Description

These shouldn't be directly set by a downstream user. We're taking advantage of the fact that we've already broken backwards compatibility in **main** to make this change.

## Checklist

- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
