### PR TITLE
Add downloader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@ members = [
     "stac",
     "stac-api",
     "stac-async",
+    "stac-cli",
 ]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Rust implementation of the [SpatioTemporal Asset Catalog (STAC)](https://stacspe
 | **stac** | Core data structures and synchronous I/O | [![README](https://img.shields.io/static/v1?label=README&message=stac&color=informational&style=flat-square)](./stac/README.md) <br> [![docs.rs](https://img.shields.io/docsrs/stac?style=flat-square)](https://docs.rs/stac/latest/stac/) <br> [![Crates.io](https://img.shields.io/crates/v/stac?style=flat-square)](https://crates.io/crates/stac) |
 | **stac-api** | Data structures for the [STAC API](https://github.com/radiantearth/stac-api-spec) specification | [![README](https://img.shields.io/static/v1?label=README&message=stac-api&color=informational&style=flat-square)](./stac-api/README.md) <br> [![docs.rs](https://img.shields.io/docsrs/stac-api?style=flat-square)](https://docs.rs/stac-api/latest/stac_api/) <br> [![Crates.io](https://img.shields.io/crates/v/stac-api?style=flat-square)](https://crates.io/crates/stac-api)
 | **stac-async** | Asynchronous I/O with [tokio](https://tokio.rs/) | [![README](https://img.shields.io/static/v1?label=README&message=stac-async&color=informational&style=flat-square)](./stac-async/README.md) <br> [![docs.rs](https://img.shields.io/docsrs/stac-async?style=flat-square)](https://docs.rs/stac-async/latest/stac_async/) <br> [![Crates.io](https://img.shields.io/crates/v/stac-async?style=flat-square)](https://crates.io/crates/stac-async)
+| **stac-cli** | Command line interface | [![README](https://img.shields.io/static/v1?label=README&message=stac-cli&color=informational&style=flat-square)](./stac-cli/README.md) <br> [![docs.rs](https://img.shields.io/docsrs/stac-cli?style=flat-square)](https://docs.rs/stac-cli/latest/stac_cli/) <br> [![Crates.io](https://img.shields.io/crates/v/stac-cli?style=flat-square)](https://crates.io/crates/stac-cli)
 
 ## Usage
 
@@ -44,6 +45,12 @@ If you're using [STAC API](https://github.com/radiantearth/stac-api-spec) data s
 stac-api = "0.1"
 ```
 
+To install the CLI:
+
+```shell
+cargo install stac-cli
+```
+
 ## Development
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for information about contributing to this project.
@@ -55,7 +62,6 @@ We have a growing suite of projects in the Rust+STAC ecosystem:
 
 - [pgstac-rs](https://github.com/gadomski/pgstac-rs): Rust interface for [pgstac](https://github.com/stac-utils/pgstac), PostgreSQL schema and functions for STAC
 - [stac-server-rs](https://github.com/gadomski/stac-server-rs): A STAC API server implementation
-- [stac-incubator-rs](https://github.com/gadomski/stac-incubator-rs): Fledgling projects not yet ready to live on their own in a standalone repo
 - [pc-rs](https://github.com/gadomski/pc-rs): Small command line utility for downloading assets from the [Planetary Computer](https://planetarycomputer.microsoft.com/)
 
 ## License

--- a/stac-async/CHANGELOG.md
+++ b/stac-async/CHANGELOG.md
@@ -13,11 +13,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Item paging ([#133](https://github.com/gadomski/stac-rs/pull/133))
 - `Client::request` and `Client::request_from_link` ([#133](https://github.com/gadomski/stac-rs/pull/133))
 - Mocks for testing ([#133](https://github.com/gadomski/stac-rs/pull/133))
+- Downloading ([#142](https://github.com/gadomski/stac-rs/pull/142))
 
 ### Changed
 
 - Refactored to modules ([#130](https://github.com/gadomski/stac-rs/pull/130))
 - `stac_async::read` now can return anything that deserializes and implements `Href` ([#135](https://github.com/gadomski/stac-rs/pull/135))
+
+### Fixed
+
+- Reading Windows hrefs ([#142](https://github.com/gadomski/stac-rs/pull/142))
 
 ## [0.3.0] - 2023-01-08
 

--- a/stac-async/Cargo.toml
+++ b/stac-async/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["science", "data-structures"]
 
 [dependencies]
 async-stream = "0.3"
+async-trait = "0.1"
 futures-core = "0.3"
 futures-util = "0.3"
 http = "0.2"
@@ -26,5 +27,6 @@ url = "2"
 
 [dev-dependencies]
 mockito = "0.32"
+tempdir = "0.3"
 tokio = { version = "1.23", features = ["rt", "macros"] }
 tokio-test = "0.4"

--- a/stac-async/src/download.rs
+++ b/stac-async/src/download.rs
@@ -1,0 +1,221 @@
+use crate::Result;
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Serialize;
+use stac::{Asset, Assets, Collection, Href, Item, Link, Links, Value};
+use std::path::Path;
+use tokio::{fs::File, io::AsyncWriteExt, task::JoinSet};
+use url::Url;
+
+const DEFAULT_FILE_NAME: &str = "download.json";
+const DEFAULT_WRITE_STAC: bool = true;
+
+/// Downloads all assets from a [Item](stac::Item) or [Collection](stac::Collection).
+///
+/// The STAC object's self href and asset hrefs are updated to point to the
+/// downloaded locations. The original object's locations is included in a
+/// "canonical" link.
+///
+/// # Examples
+///
+/// ```no_run
+/// # tokio_test::block_on(async {
+/// let value = stac_async::download("data/simple-item.json", "outdir").await.unwrap();
+/// # })
+/// ```
+pub async fn download(href: impl ToString, directory: impl AsRef<Path>) -> Result<Value> {
+    match crate::read(href).await? {
+        Value::Item(item) => item.download(directory).await.map(|item| Value::Item(item)),
+        Value::Collection(collection) => collection
+            .download(directory)
+            .await
+            .map(|collection| Value::Collection(collection)),
+        _ => unimplemented!(),
+    }
+}
+
+/// Download the assets from anything that implements [Assets].
+#[async_trait(?Send)]
+pub trait Download: Assets + Links + Href + Serialize + Clone {
+    /// Download the assets, and the object itself, to a directory on the local filesystem.
+    ///
+    /// # Examples
+    ///
+    /// [Item] implements [Download]:
+    ///
+    /// ```no_run
+    /// use stac::{Item, Links};
+    /// use stac_async::Download;
+    ///
+    /// let item: Item = stac::read("data/simple-item.json").unwrap();
+    /// # tokio_test::block_on(async {
+    /// let downloaded_item = item.download("outdir").await.unwrap();
+    /// # })
+    /// ```
+    async fn download(self, directory: impl AsRef<Path>) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        Downloader::new(self)?.download(directory).await
+    }
+}
+
+/// A customizable download structure.
+#[derive(Debug)]
+pub struct Downloader<T: Links + Assets + Href + Serialize + Clone> {
+    stac: T,
+    client: Client,
+    file_name: String,
+    write_stac: bool,
+}
+
+#[derive(Debug)]
+struct AssetDownloader {
+    key: String,
+    asset: Asset,
+    client: Client,
+}
+
+impl<T: Links + Assets + Href + Serialize + Clone> Downloader<T> {
+    /// Creates a new downloader.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let item: stac::Item = stac::read("data/simple-item.json").unwrap();
+    /// let downloader = stac_async::Downloader::new(item);
+    /// ```
+    pub fn new(mut stac: T) -> Result<Downloader<T>> {
+        let file_name = if let Some(href) = stac.href().map(|href| href.to_string()) {
+            stac.make_relative_links_absolute(&href)?;
+            // TODO detect if this should be geojson or json
+            stac.links_mut().push(Link::new(&href, "canonical"));
+            href.rsplit_once('/')
+                .map(|(_, file_name)| file_name.to_string())
+        } else {
+            let _ = stac.remove_relative_links();
+            None
+        };
+        Ok(Downloader {
+            stac,
+            client: Client::new(),
+            file_name: file_name.unwrap_or_else(|| DEFAULT_FILE_NAME.to_string()),
+            write_stac: DEFAULT_WRITE_STAC,
+        })
+    }
+
+    /// Downloads assets to the specified directory.
+    ///
+    /// Consumes this downloader, and returns the modified object.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// let item: stac::Item = stac::read("data/simple-item.json").unwrap();
+    /// let downloader = stac_async::Downloader::new(item).unwrap();
+    /// # tokio_test::block_on(async {
+    /// let item = downloader.download("outdir").await.unwrap();
+    /// # })
+    /// ```
+    pub async fn download(mut self, directory: impl AsRef<Path>) -> Result<T> {
+        let mut join_set = JoinSet::new();
+        let directory = directory.as_ref();
+        tokio::fs::create_dir_all(directory).await?;
+        for asset_downloader in self.asset_downloaders() {
+            let directory = directory.to_path_buf();
+            let _ = join_set.spawn(async move { asset_downloader.download_to(directory) });
+        }
+        let path = directory.join(self.file_name);
+        self.stac.set_link(Link::self_(path.to_string_lossy()));
+        self.stac.assets_mut().clear();
+        while let Some(result) = join_set.join_next().await {
+            let (key, asset) = result?.await?;
+            let _ = self.stac.assets_mut().insert(key, asset);
+        }
+        if self.write_stac {
+            crate::write_json_to_path(path, serde_json::to_value(self.stac.clone())?).await?;
+        }
+        Ok(self.stac)
+    }
+
+    fn asset_downloaders(&self) -> impl Iterator<Item = AssetDownloader> {
+        let client = self.client.clone();
+        self.stac
+            .assets()
+            .clone()
+            .into_iter()
+            .map(move |(key, asset)| AssetDownloader {
+                key,
+                asset,
+                client: client.clone(),
+            })
+    }
+}
+
+impl AssetDownloader {
+    async fn download_to(mut self, directory: impl AsRef<Path>) -> Result<(String, Asset)> {
+        let url = Url::parse(&self.asset.href)?;
+        let file_name = url
+            .path_segments()
+            .and_then(|s| s.last().map(|s| s.to_string()))
+            .unwrap_or_else(|| self.key.clone());
+        let mut response = self
+            .client
+            .get(self.asset.href)
+            .send()
+            .await
+            .and_then(|response| response.error_for_status())?;
+        let path = directory.as_ref().join(file_name.clone());
+        let mut file = File::create(path).await?;
+        while let Some(chunk) = response.chunk().await? {
+            file.write_all(&chunk).await?;
+        }
+        self.asset.href = format!("./{}", file_name);
+        Ok((self.key, self.asset))
+    }
+}
+
+impl Download for Item {}
+impl Download for Collection {}
+
+#[cfg(test)]
+mod tests {
+    use super::Download;
+    use mockito::Server;
+    use stac::{Asset, Href, Item, Link, Links};
+    use tempdir::TempDir;
+
+    #[tokio::test]
+    async fn download() {
+        let mut server = Server::new_async().await;
+        let download = server
+            .mock("GET", "/asset.tif")
+            .with_body("fake geotiff, sorry!")
+            .create_async()
+            .await;
+        let mut item = Item::new("an-id");
+        item.set_link(Link::collection("./collection.json"));
+        let _ = item.assets.insert(
+            "data".to_string(),
+            Asset::new(format!("{}/asset.tif", server.url())),
+        );
+        item.set_href("http://stac-async-rs.test/item.json");
+        let temp_dir = TempDir::new("download").unwrap();
+        let item = item.download(temp_dir.path()).await.unwrap();
+        download.assert_async().await;
+        assert_eq!(
+            item.link("canonical").unwrap().href,
+            "http://stac-async-rs.test/item.json"
+        );
+        assert_eq!(
+            item.collection_link().unwrap().href,
+            "http://stac-async-rs.test/collection.json"
+        );
+        let path = temp_dir.path().join("item.json");
+        assert_eq!(item.self_link().unwrap().href, path.to_string_lossy());
+        for asset in item.assets.values() {
+            assert!(temp_dir.path().join(&asset.href).exists());
+        }
+        let _: Item = crate::read(path.to_string_lossy()).await.unwrap();
+    }
+}

--- a/stac-async/src/error.rs
+++ b/stac-async/src/error.rs
@@ -17,7 +17,7 @@ pub enum Error {
 
     /// [tokio::task::JoinError]
     #[error(transparent)]
-    TokioTaskJoin(#[from] tokio::task::JoinError),
+    TokioJoin(#[from] tokio::task::JoinError),
 
     /// [http::method::InvalidMethod]
     #[error(transparent)]

--- a/stac-async/src/io.rs
+++ b/stac-async/src/io.rs
@@ -40,7 +40,7 @@ pub async fn read_json<T>(href: &str) -> Result<T>
 where
     T: DeserializeOwned,
 {
-    if let Ok(url) = Url::parse(&href) {
+    if let Some(url) = stac::href_to_url(href) {
         read_json_from_url(url).await
     } else {
         read_json_from_path(href).await

--- a/stac-async/src/lib.rs
+++ b/stac-async/src/lib.rs
@@ -44,12 +44,14 @@
 
 mod api_client;
 mod client;
+mod download;
 mod error;
 mod io;
 
 pub use {
     api_client::ApiClient,
     client::Client,
+    download::{download, Download, Downloader},
     error::Error,
     io::{read, read_json, write_json_to_path},
 };

--- a/stac-cli/CHANGELOG.md
+++ b/stac-cli/CHANGELOG.md
@@ -1,0 +1,12 @@
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+Moved over from [stac-incubator-rs](https://github.com/gadomski/stac-incubator-rs) ([#142](https://github.com/gadomski/stac-rs/pull/142))
+
+[Unreleased]: https://github.com/gadomski/stac-rs/tree/main

--- a/stac-cli/Cargo.toml
+++ b/stac-cli/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "stac-cli"
+version = "0.0.2"
+edition = "2021"
+description = "Command line interface for stac-rs"
+documentation = "https://docs.rs/stac-cli"
+readme = "README.md"
+repository = "https://github.com/gadomski/stac-incubator-rs"
+license = "MIT OR Apache-2.0"
+keywords = ["geospatial", "stac", "metadata", "geo", "raster"]
+categories = ["science", "data-structures"]
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+console = "0.15"
+indicatif = "0.17"
+reqwest = "0.11"
+serde = "1"
+stac = { version = "0.3", features = ["jsonschema"], path = "../stac" }
+stac-async = { version = "0.3", path = "../stac-async" }
+thiserror = "1"
+tokio = { version = "1.23", features = ["macros", "rt-multi-thread"] }
+url = "2"
+
+[[bin]]
+name = "stac"
+path = "src/main.rs"
+doc = false
+test = false

--- a/stac-cli/README.md
+++ b/stac-cli/README.md
@@ -1,0 +1,36 @@
+# stac-cli
+
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/gadomski/stac-rs/ci.yml?branch=main&style=for-the-badge)](https://github.com/gadomski/stac-rs/actions/workflows/ci.yml)
+[![docs.rs](https://img.shields.io/docsrs/stac-cli?style=for-the-badge)](https://docs.rs/stac-cli/latest/stac_cli/)
+[![Crates.io](https://img.shields.io/crates/v/stac-cli?style=for-the-badge)](https://crates.io/crates/stac-cli)
+![Crates.io](https://img.shields.io/crates/l/stac-cli?style=for-the-badge)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=for-the-badge)](./CODE_OF_CONDUCT)
+
+Command line interface to [stac-rs](https://github.com/gadomski/stac-rs).
+
+## Installation
+
+Install rust.
+[rustup](https://rustup.rs/) works well.
+Once you do:
+
+```sh
+cargo install --git https://github.com/gadomski/stac-rs
+```
+
+## Usage
+
+Use the cli `--help` flag to see all available options:
+
+```shell
+stac --help
+```
+
+### Download
+
+Download all the assets of a STAC item.
+The STAC item will be written out, with its assets updated to point to the locally downloaded assets.
+
+```shell
+stac download https://raw.githubusercontent.com/radiantearth/stac-spec/master/examples/simple-item.json .
+```

--- a/stac-cli/src/args.rs
+++ b/stac-cli/src/args.rs
@@ -1,0 +1,49 @@
+use crate::Result;
+use clap::{Parser, Subcommand};
+use stac::Value;
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Download assets.
+    Download {
+        /// The href of the STAC object.
+        href: String,
+
+        /// Assets will be downloaded to this directory.
+        directory: PathBuf,
+
+        /// If the directory does not exist, should be it be created?
+        #[arg(short, long, default_value_t = true)]
+        create_directory: bool,
+    },
+}
+
+impl Command {
+    pub async fn execute(self) -> Result<()> {
+        use Command::*;
+        match self {
+            Download {
+                href,
+                directory,
+                create_directory,
+            } => {
+                use Value::*;
+                match stac_async::read(href).await? {
+                    Collection(collection) => {
+                        crate::download(collection, directory, create_directory).await?
+                    }
+                    Item(item) => crate::download(item, directory, create_directory).await?,
+                    _ => unimplemented!(),
+                }
+                Ok(())
+            }
+        }
+    }
+}

--- a/stac-cli/src/download.rs
+++ b/stac-cli/src/download.rs
@@ -1,0 +1,14 @@
+use crate::Result;
+use serde::Serialize;
+use stac::{Assets, Href, Links};
+use stac_async::Downloader;
+use std::path::Path;
+
+pub async fn download<A>(assets: A, directory: impl AsRef<Path>, _: bool) -> Result<()>
+where
+    A: Assets + Href + Links + Serialize + Clone,
+{
+    let downloader = Downloader::new(assets)?;
+    downloader.download(directory).await?;
+    Ok(())
+}

--- a/stac-cli/src/error.rs
+++ b/stac-cli/src/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    StacAsync(#[from] stac_async::Error),
+}
+
+impl Error {
+    pub fn return_code(&self) -> i32 {
+        unimplemented!()
+    }
+}

--- a/stac-cli/src/lib.rs
+++ b/stac-cli/src/lib.rs
@@ -1,0 +1,11 @@
+mod args;
+mod download;
+mod error;
+
+pub use {
+    args::{Args, Command},
+    download::download,
+    error::Error,
+};
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/stac-cli/src/main.rs
+++ b/stac-cli/src/main.rs
@@ -1,0 +1,14 @@
+use clap::Parser;
+use stac_cli::Args;
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+    match args.command.execute().await {
+        Ok(()) => return,
+        Err(err) => {
+            eprintln!("ERROR: {}", err);
+            std::process::exit(err.return_code())
+        }
+    }
+}

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `Deserialize` for `Value` ([#135](https://github.com/gadomski/stac-rs/pull/135))
 - `type` checks on (de)serialization ([#136](https://github.com/gadomski/stac-rs/pull/136))
 - `Assets` trait ([#137](https://github.com/gadomski/stac-rs/pull/137))
+- `Link::remove_relative_hrefs` ([#142](https://github.com/gadomski/stac-rs/pull/142))
+- `stac::href_to_url` ([#142](https://github.com/gadomski/stac-rs/pull/142))
 
 ### Changed
 

--- a/stac/src/href.rs
+++ b/stac/src/href.rs
@@ -1,3 +1,5 @@
+use url::Url;
+
 /// Implemented by all three STAC objects, the [Href] trait allows getting and setting an object's href.
 ///
 /// Though the href isn't part of the data structure, it is useful to know where a given STAC object was read from.
@@ -18,4 +20,28 @@ pub trait Href {
 
     /// Sets this object's href.
     fn set_href(&mut self, href: impl ToString);
+}
+
+/// Parses an href into a [Url] if the scheme is `http` or `https`.
+///
+/// Otherwise, returns `None`. This is useful for determining whether
+/// a given href should be opened with a local filesystem reader or
+/// [reqwest].
+///
+/// # Examples
+///
+/// ```
+/// assert!(stac::href_to_url("C:\\\\data").is_none());
+/// assert!(stac::href_to_url("http://stac-rs.test").is_some());
+/// ```
+pub fn href_to_url(href: &str) -> Option<Url> {
+    if let Ok(url) = Url::parse(href) {
+        if url.scheme().starts_with("http") {
+            Some(url)
+        } else {
+            None
+        }
+    } else {
+        None
+    }
 }

--- a/stac/src/io.rs
+++ b/stac/src/io.rs
@@ -28,7 +28,7 @@ pub fn read_json<T>(href: &str) -> Result<T>
 where
     T: DeserializeOwned,
 {
-    if let Ok(url) = Url::parse(&href) {
+    if let Some(url) = crate::href_to_url(href) {
         read_json_from_url(url)
     } else {
         read_json_from_path(href)

--- a/stac/src/lib.rs
+++ b/stac/src/lib.rs
@@ -148,7 +148,7 @@ pub use {
     collection::{Collection, Extent, Provider, SpatialExtent, TemporalExtent, COLLECTION_TYPE},
     error::Error,
     extensions::Extensions,
-    href::Href,
+    href::{href_to_url, Href},
     io::{read, read_json},
     item::{Item, Properties, ITEM_TYPE},
     item_collection::{ItemCollection, ITEM_COLLECTION_TYPE},


### PR DESCRIPTION
## Closes

- Closes #134 

## Related to

After we merge this, we can archive https://github.com/gadomski/stac-incubator-rs -- its watch has ended.

## Description

Brought over the cli to exercise the downloader. We'll need to add progress reporting back in, but I'll track that in a new issue.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
