### PR TITLE
Release stac v0.4.0

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,18 +2,15 @@
 
 ## Checklist
 
-1. Determine which packages you're releasing. While its not required, its
-probably safest to release most or all of the packages at the same time -- use
-your best judgement.
-2. Create a release branch.
-    - If you're only releasing one version (e.g. for a bugfix), name it `release/{package name}-{version}`, e.g. `release/stac-v1.2.3`.
-    - If you're releasing multiple versions, just use the date, e.g. `release/2023-02-26`.
-3. Determine each package's next version, and update their `Cargo.toml` files accordingly.
-4. Scan each README for references to version numbers, and update any that are needed.
-5. Update each package's CHANGELOG with a new section for the new version. Don't forget to update the links at the bottom, too.
-6. Test the release with `cargo release`. By default, this does a dry-run, so it won't actually do anything. If you're _not_ releasing every package, specify the packages you want with the `-p` flag.
-7. Use the normal pull request workflow to merge your branch.
-8. Once merged, run `cargo release --execute` to do the release. Use the same `-p` flags as you did during the dry run.
+1. Determine which package you're releasing. Only release one package at a time.
+2. Determine the package's next version
+3. Create a release branch named `release/{package name}-{version}`, e.g. `release/stac-v1.2.3`.
+4. Update the package's `Cargo.toml` file accordingly, and update the other packages' `Cargo.toml` if they depend on this package.
+5. Scan the package's README for references to version numbers, and update any that are needed.
+6. Update the package's CHANGELOG with a new section for the new version. Don't forget to update the links at the bottom, too.
+7. Test the release with `cargo release -p {package name}`. By default, this does a dry-run, so it won't actually do anything.
+8. Use the normal pull request workflow to merge your branch.
+9. Once merged, run `cargo release --execute` to do the release. Use the same `-p` flags as you did during the dry run.
 
 ## After-the-fact releases
 

--- a/stac-api/Cargo.toml
+++ b/stac-api/Cargo.toml
@@ -15,6 +15,6 @@ geojson = "0.24"
 serde = "1"
 serde_json = "1"
 serde_urlencoded = "0.7"
-stac = { version = "0.3", path = "../stac" }
+stac = { version = "0.4", path = "../stac" }
 thiserror = "1"
 url = "2.3"

--- a/stac-async/Cargo.toml
+++ b/stac-async/Cargo.toml
@@ -19,7 +19,7 @@ http = "0.2"
 reqwest = { version ="0.11", features = ["json"] }
 serde = "1"
 serde_json = "1"
-stac = { version = "0.3", path = "../stac" }
+stac = { version = "0.4", path = "../stac" }
 stac-api = { version = "0.1", path = "../stac-api" }
 thiserror = "1"
 tokio = { version = "1.23", features = ["fs", "io-util"] }

--- a/stac-cli/Cargo.toml
+++ b/stac-cli/Cargo.toml
@@ -16,7 +16,7 @@ console = "0.15"
 indicatif = "0.17"
 reqwest = "0.11"
 serde = "1"
-stac = { version = "0.3", features = ["jsonschema"], path = "../stac" }
+stac = { version = "0.4", features = ["jsonschema"], path = "../stac" }
 stac-async = { version = "0.3", path = "../stac-async" }
 thiserror = "1"
 tokio = { version = "1.23", features = ["macros", "rt-multi-thread"] }

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.4.0] - 2023-04-01
+
 ### Added
 
 - `Deserialize` for `Value` ([#135](https://github.com/gadomski/stac-rs/pull/135))
@@ -210,7 +212,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Initial release.
 
-[Unreleased]: https://github.com/gadomski/stac-rs/compare/stac-v0.3.1...main
+[Unreleased]: https://github.com/gadomski/stac-rs/compare/stac-v0.4.0...main
+[0.4.0]: https://github.com/gadomski/stac-rs/compare/stac-v0.3.2...stac-v0.4.0
 [0.3.2]: https://github.com/gadomski/stac-rs/compare/stac-v0.3.1...stac-v0.3.2
 [0.3.1]: https://github.com/gadomski/stac-rs/compare/stac-v0.3.0...stac-v0.3.1
 [0.3.0]: https://github.com/gadomski/stac-rs/compare/v0.2.0...stac-v0.3.0

--- a/stac/Cargo.toml
+++ b/stac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stac"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Pete Gadomski <pete.gadomski@gmail.com>"]
 edition = "2021"
 description = "Rust library for the SpatioTemporal Asset Catalog (STAC) specification"
@@ -18,7 +18,7 @@ set_query = ["dep:serde_urlencoded"]
 [dependencies]
 chrono = "0.4"
 geojson = "0.24"
-jsonschema = { version = "0.16", optional = true, features = ["resolve-http"], default-features = false }
+jsonschema = { version = "0.17", optional = true, features = ["resolve-http"], default-features = false }
 reqwest = { version = "0.11", optional = true, features = ["json", "blocking"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/stac/README.md
+++ b/stac/README.md
@@ -14,7 +14,7 @@ To use the library in your project:
 
 ```toml
 [dependencies]
-stac = "0.3"
+stac = "0.4"
 ```
 
 ### Features
@@ -27,7 +27,7 @@ The `jsonschema` feature enables validation against [json-schema](https://json-s
 
 ```toml
 [dependencies]
-stac = { version = "0.3", features = ["jsonschema"]}
+stac = { version = "0.4", features = ["jsonschema"]}
 ```
 
 The `jsonschema` feature also enables the `reqwest` feature.
@@ -38,7 +38,7 @@ If you'd like to use the library with `reqwest` for blocking remote reads:
 
 ```toml
 [dependencies]
-stac = { version = "0.3", features = ["reqwest"]}
+stac = { version = "0.4", features = ["reqwest"]}
 ```
 
 If `reqwest` is not enabled, `stac::read` will throw an error if you try to read from a url.
@@ -50,7 +50,7 @@ It is behind a feature because it adds a dependency, [serde_urlencoded](https://
 To enable:
 
 ```toml
-stac = { version = "0.3", features = ["set_query"]}
+stac = { version = "0.4", features = ["set_query"]}
 ```
 
 ## Examples


### PR DESCRIPTION
## Description

Also, update the releasing docs.

## Checklist

- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
