### PR TITLE
Release stac-async v0.4.0

### DIFF
--- a/stac-async/CHANGELOG.md
+++ b/stac-async/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.4.0] - 2023-04-03
+
 ### Added
 
 - `ApiClient` ([#130](https://github.com/gadomski/stac-rs/pull/130))
@@ -32,6 +34,7 @@ No changes.
 
 Initial release of **stac-async**.
 
-[Unreleased]: https://github.com/gadomski/stac-rs/compare/stac-async-v0.3.0...main
+[Unreleased]: https://github.com/gadomski/stac-rs/compare/stac-async-v0.4.0...main
+[0.4.0]: https://github.com/gadomski/stac-rs/compare/stac-async-v0.3.0...stac-async-v0.4.0
 [0.3.0]: https://github.com/gadomski/stac-rs/compare/stac-async-v0.2.0...stac-async-v0.3.0
 [0.2.0]: https://github.com/gadomski/stac-rs/releases/tag/stac-async-v0.2.0

--- a/stac-async/Cargo.toml
+++ b/stac-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stac-async"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Asynchronous I/O for stac-rs"
 documentation = "https://docs.rs/stac-async"
@@ -26,7 +26,7 @@ tokio = { version = "1.23", features = ["fs", "io-util"] }
 url = "2"
 
 [dev-dependencies]
-mockito = "0.32"
+mockito = "1"
 tempdir = "0.3"
 tokio = { version = "1.23", features = ["rt", "macros"] }
 tokio-test = "0.4"

--- a/stac-async/README.md
+++ b/stac-async/README.md
@@ -12,8 +12,8 @@ Asynchronous I/O for the [SpatioTemporal Asset Catalog (STAC)](https://stacspec.
 
 ```toml
 [dependencies]
-stac = "0.3"
-stac-async = "0.3"
+stac = "0.4"
+stac-async = "0.4"
 ```
 
 ## Examples

--- a/stac-cli/Cargo.toml
+++ b/stac-cli/Cargo.toml
@@ -17,7 +17,7 @@ indicatif = "0.17"
 reqwest = "0.11"
 serde = "1"
 stac = { version = "0.4", features = ["jsonschema"], path = "../stac" }
-stac-async = { version = "0.3", path = "../stac-async" }
+stac-async = { version = "0.4", path = "../stac-async" }
 thiserror = "1"
 tokio = { version = "1.23", features = ["macros", "rt-multi-thread"] }
 url = "2"


### PR DESCRIPTION
## Description

We might have gotten away with a minor release, but it's hard to tell b/c of the refactor so better safe then sorry.

## Checklist

- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
