### PR TITLE
Add stac-async docs

### DIFF
--- a/stac-async/src/api_client.rs
+++ b/stac-async/src/api_client.rs
@@ -51,7 +51,11 @@ impl ApiClient {
         self.client.get(url).await
     }
 
-    /// Returns a stream of items belonging to a collection.
+    /// Returns a stream of items belonging to a collection, using the [items
+    /// endpoint](https://github.com/radiantearth/stac-api-spec/tree/main/ogcapi-features#collection-items-collectionscollectioniditems).
+    ///
+    /// The `items` argument can be used to filter, sort, and otherwise
+    /// configure the request.
     ///
     /// # Examples
     ///
@@ -82,7 +86,7 @@ impl ApiClient {
         id: &str,
         items: impl Into<Option<Items>>,
     ) -> Result<impl Stream<Item = Result<Item>>> {
-        let url = self.url_builder.items(id)?;
+        let url = self.url_builder.items(id)?; // TODO HATEOS
         let items = if let Some(items) = items.into() {
             Some(items.into_get_items()?)
         } else {

--- a/stac-async/src/download.rs
+++ b/stac-async/src/download.rs
@@ -178,7 +178,27 @@ impl<T: Links + Assets + Href + Serialize + Clone> Downloader<T> {
     ///
     /// # Examples
     ///
-    /// TODO
+    /// ```no_run
+    /// use tokio::sync::mpsc;
+    /// use stac_async::Downloader;
+    /// use stac::Item;
+    ///
+    /// let (tx, mut rx)  = mpsc::channel(100);
+    /// let item: Item = stac::read("data/simple-item.json").unwrap();
+    /// let downloader = Downloader::new(item)
+    ///     .unwrap()
+    ///     .with_sender(tx);
+    ///
+    /// # tokio_test::block_on(async {
+    /// tokio::spawn(async move {
+    ///     downloader.download(".").await.unwrap()
+    /// });
+    ///
+    /// while let Some(message) = rx.recv().await {
+    ///     dbg!(message);
+    /// }
+    /// # })
+    /// ```
     pub fn with_sender(mut self, sender: Sender<Message>) -> Downloader<T> {
         self.sender = Some(sender);
         self

--- a/stac-async/src/lib.rs
+++ b/stac-async/src/lib.rs
@@ -1,14 +1,36 @@
 //! Asynchronous I/O for [STAC](https://stacspec.org/), built on [stac-rs](https://github.com/gadomski/stac-rs)
 //!
-//! This is just a small library that provides an async version of [stac::read].
-//! It also includes a thin wrapper around [reqwest::Client] for efficiently
-//! getting multiple STAC items in the same session.
-//!
 //! # Examples
+//!
+//! Read a single STAC item:
 //!
 //! ```
 //! # tokio_test::block_on(async {
 //! let item: stac::Item = stac_async::read("data/simple-item.json").await.unwrap();
+//! # })
+//! ```
+//!
+//! Build an API client to read from a [STAC API](https://github.com/radiantearth/stac-api-spec):
+//!
+//! ```no_run
+//! use futures_util::StreamExt;
+//! let url = "https://planetary-computer.microsoft.com/api/stac/v1";
+//! let api_client = stac_async::ApiClient::new(url).unwrap();
+//! # tokio_test::block_on(async {
+//! // Get the first sentinel2 item using an asynchronous stream
+//! let items = api_client.items("sentinel2-l2a", None).await.unwrap();
+//! tokio::pin!(items);
+//! let item = items.next().await.unwrap().unwrap();
+//! # })
+//! ```
+//!
+//! Download assets from an item:
+//!
+//! ```no_run
+//! use stac_async::Download;
+//! # tokio_test::block_on(async {
+//! let item: stac::Item = stac_async::read("data/simple-item.json").await.unwrap();
+//! item.download("target-directory").await.unwrap();
 //! # })
 //! ```
 


### PR DESCRIPTION
## Closes

- Closes #163 

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [ ] Changes are added to the CHANGELOG
