### PR TITLE
Remove set query pairs

### DIFF
--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - `Links::remove_structural_links`, and more rel types to `Link::is_structural` ([#170](https://github.com/gadomski/stac-rs/pull/170))
 
+### Removed
+
+- `Link::set_query` ([#171](https://github.com/gadomski/stac-rs/pull/171))
+
 ## [0.4.0] - 2023-04-01
 
 ### Added

--- a/stac/Cargo.toml
+++ b/stac/Cargo.toml
@@ -13,7 +13,6 @@ categories = ["science", "data-structures"]
 [features]
 jsonschema = ["dep:jsonschema", "reqwest"]
 reqwest = ["dep:reqwest"]
-set_query = ["dep:serde_urlencoded"]
 
 [dependencies]
 chrono = "0.4"
@@ -22,7 +21,6 @@ jsonschema = { version = "0.17", optional = true, features = ["resolve-http"], d
 reqwest = { version = "0.11", optional = true, features = ["json", "blocking"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
-serde_urlencoded = { version = "0.7", optional = true }
 thiserror = "1"
 url = "2"
 

--- a/stac/src/link.rs
+++ b/stac/src/link.rs
@@ -618,31 +618,6 @@ impl Link {
     pub fn is_absolute(&self) -> bool {
         is_absolute(&self.href)
     }
-
-    /// Sets a link's href's query to anything serializable by [serde_urlencoded].
-    ///
-    /// Raises an error if the href is not parseable as a url. Requires the
-    /// `set_query` feature to be enabled.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use stac::Link;
-    /// let mut link = Link::new("http://stac-rs.test/", "a-rel");
-    /// link.set_query([("foo", "bar")]).unwrap();
-    /// assert_eq!(link.href, "http://stac-rs.test/?foo=bar");
-    /// ```
-    #[cfg(feature = "set_query")]
-    pub fn set_query<Q>(&mut self, query: Q) -> Result<()>
-    where
-        Q: Serialize,
-    {
-        let mut url: Url = self.href.parse()?;
-        let query = serde_urlencoded::to_string(query)?;
-        url.set_query(Some(&query));
-        self.href = url.to_string();
-        Ok(())
-    }
 }
 
 fn is_absolute(href: &str) -> bool {


### PR DESCRIPTION
## Description
Not used anymore. Breaking on **stac**.

## Checklist

Delete any checklist items that do not apply (e.g. if your change is minor, it may not require documentation updates).

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
