### PR TITLE
Make `Links.remove_*` the same-ish

### DIFF
--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `Links::remove_relative_links` has the same vibe as `Links::remove_structural_links` ([#176](https://github.com/gadomski/stac-rs/pull/176))
+
 ## [0.5.0] - 2023-06-27
 
 ### Added

--- a/stac/src/link.rs
+++ b/stac/src/link.rs
@@ -240,7 +240,6 @@ pub trait Links {
     ///
     /// This can be useful e.g. if you're relocating a STAC object, but it
     /// doesn't have a href, so the relative links wouldn't make any sense.
-    /// Returns all removed links.
     ///
     /// # Examples
     ///
@@ -251,21 +250,11 @@ pub trait Links {
     /// catalog.remove_relative_links();
     /// assert!(catalog.links.is_empty());
     /// ```
-    fn remove_relative_links(&mut self) -> Vec<Link> {
-        let mut i = 0;
-        let mut removed = Vec::new();
-        // Replace with `drain_filter` when it is stabilized.
-        while i < self.links().len() {
-            if !self.links()[i].is_absolute() {
-                removed.push(self.links_mut().remove(i));
-            } else {
-                i += 1;
-            }
-        }
-        removed
+    fn remove_relative_links(&mut self) {
+        self.links_mut().retain(|link| link.is_absolute())
     }
 
-    /// Removes and returns all structural links.
+    /// Removes all structural links.
     ///
     /// Useful if you're, e.g., going to re-populate the structural links as a
     /// part of serving items with a STAC API.
@@ -758,9 +747,8 @@ mod tests {
             catalog
                 .links
                 .push(Link::new("http://stac-rs.test/child.json", "child"));
-            let removed = catalog.remove_relative_links();
+            catalog.remove_relative_links();
             assert_eq!(catalog.links.len(), 2);
-            assert_eq!(removed.len(), 1);
         }
     }
 }


### PR DESCRIPTION
## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
