### PR TITLE
Add schemars support

### DIFF
--- a/stac-api/CHANGELOG.md
+++ b/stac-api/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Conformance URIs ([#170](https://github.com/gadomski/stac-rs/pull/170))
+- `schemars` feature ([#177](https://github.com/gadomski/stac-rs/pull/177))
 
 ### Changed
 

--- a/stac-api/Cargo.toml
+++ b/stac-api/Cargo.toml
@@ -10,8 +10,11 @@ license = "MIT OR Apache-2.0"
 keywords = ["geospatial", "stac", "metadata", "geo", "raster"]
 categories = ["science", "data-structures", "web-programming"]
 
+[features]
+schemars = ["dep:schemars", "stac/schemars"]
+
 [dependencies]
-geojson = "0.24"
+schemars = { version = "0.8", optional = true }
 serde = "1"
 serde_json = "1"
 serde_urlencoded = "0.7"

--- a/stac-api/README.md
+++ b/stac-api/README.md
@@ -19,6 +19,14 @@ To use the library in your project:
 stac-api = "0.2"
 ```
 
+**stac-api** has one optional feature, `schemars`, which can be used to generate [jsonschema](https://json-schema.org/) documents for the API structures.
+This is useful for auto-generating OpenAPI documentation:
+
+```toml
+[dependencies]
+stac-api = { version = "0.2", features = ["schemars"] }
+```
+
 ## Examples
 
 ```rust

--- a/stac-api/src/collections.rs
+++ b/stac-api/src/collections.rs
@@ -4,6 +4,7 @@ use stac::{Collection, Link, Links};
 
 /// Object containing an array of Collection objects in the Catalog, and Link relations.
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Collections {
     /// The [Collection] objects in the [stac::Catalog].
     pub collections: Vec<Collection>,

--- a/stac-api/src/conformance.rs
+++ b/stac-api/src/conformance.rs
@@ -20,6 +20,7 @@ pub const GEOJSON_URI: &str = "http://www.opengis.net/spec/ogcapi-features-1/1.0
 /// implementations - and not "just" a specific API / server, the server has to
 /// declare the conformance classes it implements and conforms to.
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Conformance {
     /// The conformance classes it implements and conforms to.
     #[serde(rename = "conformsTo")]

--- a/stac-api/src/fields.rs
+++ b/stac-api/src/fields.rs
@@ -14,6 +14,7 @@ use std::{
 /// specification provides a mechanism for clients to request that servers to
 /// explicitly include or exclude certain fields.
 #[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Fields {
     /// Fields to include.
     #[serde(skip_serializing_if = "Vec::is_empty")]

--- a/stac-api/src/filter.rs
+++ b/stac-api/src/filter.rs
@@ -4,6 +4,7 @@ use serde_json::{Map, Value};
 /// The language of the filter expression.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "filter-lang", content = "filter")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum Filter {
     /// `cql2-text`
     #[serde(rename = "cql2-text")]

--- a/stac-api/src/item_collection.rs
+++ b/stac-api/src/item_collection.rs
@@ -12,6 +12,7 @@ const ITEM_COLLECTION_TYPE: &str = "FeatureCollection";
 /// not be. Defined by the [itemcollection
 /// fragment](https://github.com/radiantearth/stac-api-spec/blob/main/fragments/itemcollection/README.md).
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ItemCollection {
     /// Always "FeatureCollection" to provide compatibility with GeoJSON.
     pub r#type: String,
@@ -46,6 +47,7 @@ pub struct ItemCollection {
 ///
 /// Part of the [context extension](https://github.com/stac-api-extensions/context).
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Context {
     /// The count of results returned by this response. Equal to the cardinality
     /// of features array.

--- a/stac-api/src/items.rs
+++ b/stac-api/src/items.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 /// This is a lot like [Search](crate::Search), but without intersects, ids, and
 /// collections.
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Items {
     /// The maximum number of results to return (page size).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -58,6 +59,7 @@ pub struct Items {
 /// This is a lot like [Search](crate::Search), but without intersects, ids, and
 /// collections.
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct GetItems {
     /// The maximum number of results to return (page size).
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/stac-api/src/root.rs
+++ b/stac-api/src/root.rs
@@ -24,6 +24,7 @@ use stac::Catalog;
 ///     URI is listed then the service must implement all of the required
 ///     capabilities.
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Root {
     /// The [stac::Catalog].
     #[serde(flatten)]

--- a/stac-api/src/search.rs
+++ b/stac-api/src/search.rs
@@ -1,10 +1,11 @@
 use crate::{Fields, Filter, Sortby};
-use geojson::Geometry;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use stac::Geometry;
 
 /// The core parameters for STAC search are defined by OAFeat, and STAC adds a few parameters for convenience.
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Search {
     /// The maximum number of results to return (page size).
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/stac-api/src/sort.rs
+++ b/stac-api/src/sort.rs
@@ -7,6 +7,7 @@ use std::{
 
 /// Fields by which to sort results.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Sortby {
     /// The field to sort by.
     pub field: String,
@@ -16,6 +17,7 @@ pub struct Sortby {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum Direction {
     #[serde(rename = "asc")]
     Ascending,

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - `geo` feature ([#178](https://github.com/gadomski/stac-rs/pull/178))
+- `schemars` feature ([#177](https://github.com/gadomski/stac-rs/pull/177))
 
 ### Changed
 

--- a/stac/Cargo.toml
+++ b/stac/Cargo.toml
@@ -13,12 +13,14 @@ categories = ["science", "data-structures"]
 [features]
 geo = ["dep:geo", "dep:geojson"]
 reqwest = ["dep:reqwest"]
+schemars = ["dep:schemars"]
 
 [dependencies]
 chrono = "0.4"
 geo = { version = "0.25", optional = true }
 geojson = { version = "0.24", optional = true }
 reqwest = { version = "0.11", optional = true, features = ["json", "blocking"] }
+schemars = { version = "0.8", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "1"

--- a/stac/README.md
+++ b/stac/README.md
@@ -33,7 +33,7 @@ Please see the [documentation](https://docs.rs/stac) for more usage examples.
 
 ## Features
 
-There are two opt-in features.
+There are three opt-in features.
 
 ### reqwest
 
@@ -86,4 +86,14 @@ let mut item = Item::new("an-id");
     item.set_geometry(geometry).unwrap();
     assert!(item.bbox.is_some());
 }
+```
+
+### schemars
+
+`schemars` allows for [jsonschema](https://json-schema.org/) generation from STAC objects.
+This is mostly useful for auto-generating OpenAPI documentation for STAC APIs.
+
+```toml
+[dependencies]
+stac = { version = "0.5", features = ["schemars"]}
 ```

--- a/stac/src/asset.rs
+++ b/stac/src/asset.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 /// An Asset is an object that contains a URI to data associated with the [Item](crate::Item) that can be downloaded or streamed.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Asset {
     /// URI to the asset object.
     ///

--- a/stac/src/catalog.rs
+++ b/stac/src/catalog.rs
@@ -18,6 +18,7 @@ pub const CATALOG_TYPE: &str = "Catalog";
 /// Their purpose is discovery: to be browsed by people or be crawled by clients
 /// to build a searchable index.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Catalog {
     /// A list of extension identifiers the `Catalog` implements.
     #[serde(rename = "stac_extensions")]

--- a/stac/src/collection.rs
+++ b/stac/src/collection.rs
@@ -21,6 +21,7 @@ const DEFAULT_LICENSE: &str = "proprietary";
 /// contains all the required fields is a valid STAC `Collection` and also a valid
 /// STAC `Catalog`.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Collection {
     /// A list of extension identifiers the `Collection` implements.
     #[serde(rename = "stac_extensions")]
@@ -97,6 +98,7 @@ pub struct Collection {
 /// data offered by this `Collection`. May also include information about the
 /// final storage provider hosting the data.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Provider {
     /// The name of the organization or the individual.
     pub name: String,
@@ -126,6 +128,7 @@ pub struct Provider {
 
 /// The object describes the spatio-temporal extents of the [Collection](crate::Collection).
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Extent {
     /// Spatial extents covered by the `Collection`.
     pub spatial: SpatialExtent,
@@ -139,6 +142,7 @@ pub struct Extent {
 
 /// The object describes the spatial extents of the Collection.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SpatialExtent {
     /// Potential spatial extents covered by the Collection.
     pub bbox: Vec<Vec<f64>>,
@@ -146,6 +150,7 @@ pub struct SpatialExtent {
 
 /// The object describes the temporal extents of the Collection.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct TemporalExtent {
     /// Potential temporal extents covered by the Collection.
     pub interval: Vec<[Option<String>; 2]>,

--- a/stac/src/item.rs
+++ b/stac/src/item.rs
@@ -83,6 +83,7 @@ pub struct Item {
 
 /// Additional metadata fields can be added to the GeoJSON Object Properties.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Geometry {
     /// The geometry type.
     pub r#type: String,

--- a/stac/src/link.rs
+++ b/stac/src/link.rs
@@ -32,6 +32,7 @@ pub const COLLECTION_REL: &str = "collection";
 /// crate](https://github.com/gadomski/stac-rs/stac-api), but in this case it
 /// was simpler to include these attributes in the base [Link] rather to create a new one.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Link {
     /// The actual link in the format of an URL.
     ///


### PR DESCRIPTION
## Related to

Will (hopefully) enable OpenAPI documentation for **stac-server-rs**.

## Description

Needs geojson schemars support, or we need to implement or own geometry class. Neither option is awesome.

## Checklist


- [ ] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
