### PR TITLE
Use our own Geometry struct

### DIFF
--- a/stac-validate/Cargo.toml
+++ b/stac-validate/Cargo.toml
@@ -21,3 +21,4 @@ url = "2"
 
 [dev-dependencies]
 geojson = "0.24"
+stac = { version = "0.5", path = "../stac", features = ["geo"] }

--- a/stac-validate/src/lib.rs
+++ b/stac-validate/src/lib.rs
@@ -83,7 +83,8 @@ mod tests {
     #[test]
     fn item_with_geometry() {
         let mut item = Item::new("an-id");
-        item.set_geometry(Geometry::new(Value::Point(vec![-105.1, 40.1])));
+        item.set_geometry(Geometry::new(Value::Point(vec![-105.1, 40.1])))
+            .unwrap();
         item.validate().unwrap();
     }
 

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -6,9 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `geo` feature ([#178](https://github.com/gadomski/stac-rs/pull/178))
+
 ### Changed
 
 - `Links::remove_relative_links` has the same vibe as `Links::remove_structural_links` ([#176](https://github.com/gadomski/stac-rs/pull/176))
+- Use our own `Geometry` structure ([#178](https://github.com/gadomski/stac-rs/pull/178))
 
 ## [0.5.0] - 2023-06-27
 

--- a/stac/Cargo.toml
+++ b/stac/Cargo.toml
@@ -11,12 +11,13 @@ keywords = ["geospatial", "stac", "metadata", "geo", "raster"]
 categories = ["science", "data-structures"]
 
 [features]
+geo = ["dep:geo", "dep:geojson"]
 reqwest = ["dep:reqwest"]
 
 [dependencies]
 chrono = "0.4"
-geo = "0.25"
-geojson = "0.24"
+geo = { version = "0.25", optional = true }
+geojson = { version = "0.24", optional = true }
 reqwest = { version = "0.11", optional = true, features = ["json", "blocking"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/stac/README.md
+++ b/stac/README.md
@@ -33,7 +33,11 @@ Please see the [documentation](https://docs.rs/stac) for more usage examples.
 
 ## Features
 
-There is one opt-in feature, `reqwest`, for blocking remote reads:
+There are two opt-in features.
+
+### reqwest
+
+`reqwest` enables blocking remote reads:
 
 ```toml
 [dependencies]
@@ -57,3 +61,29 @@ let err = stac::read::<stac::Item>(href).unwrap_err();
 ```
 
 For non-blocking IO, use the [**stac-async**](https://crates.io/crates/stac-async) crate.
+
+### geo
+
+To use [geojson](https://docs.rs/geojson) and [geo](https://docs.rs/geo) to add some extra geo-enabled methods:
+
+```toml
+[dependencies]
+stac = { version = "0.5", features = ["geo"] }
+```
+
+Then, you can set an item's geometry and bounding box at the same time:
+
+```rust
+use stac::Item;
+use geojson::{Geometry, Value};
+
+let geometry = Geometry::new(Value::Point(vec![
+    -105.1, 41.1,
+]));
+let mut item = Item::new("an-id");
+#[cfg(feature = "geo")]
+{
+    item.set_geometry(geometry).unwrap();
+    assert!(item.bbox.is_some());
+}
+```

--- a/stac/src/lib.rs
+++ b/stac/src/lib.rs
@@ -131,7 +131,7 @@ pub use {
     extensions::Extensions,
     href::{href_to_url, Href},
     io::{read, read_json},
-    item::{Item, Properties, ITEM_TYPE},
+    item::{Geometry, Item, Properties, ITEM_TYPE},
     item_collection::{ItemCollection, ITEM_COLLECTION_TYPE},
     link::{Link, Links},
     value::Value,


### PR DESCRIPTION
## Related to

- Will enable #177 

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
