### PR TITLE
Make (de)serialize_type public

### DIFF
--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `schemars` feature ([#177](https://github.com/gadomski/stac-rs/pull/177))
 - `intersects_bbox` and `intersects_datetimes` for `Item` ([#180](https://github.com/gadomski/stac-rs/pull/180), [#182](https://github.com/gadomski/stac-rs/pull/182))
 - `geo` and `datetime` modules ([#182](https://github.com/gadomski/stac-rs/pull/182))
+- `(de)serialize_type` to the public interface ([#187](https://github.com/gadomski/stac-rs/pull/187))
 
 ### Changed
 

--- a/stac/src/lib.rs
+++ b/stac/src/lib.rs
@@ -146,7 +146,11 @@ pub const STAC_VERSION: &str = "1.0.0";
 /// Custom [Result](std::result::Result) type for this crate.
 pub type Result<T> = std::result::Result<T, Error>;
 
-pub(crate) fn deserialize_type<'de, D>(
+/// Utility function to deserialize the type field on an object.
+///
+/// Use this, via a wrapper function, in `#[serde(deserialize_with)]`.  See
+/// [Item] for one example.
+pub fn deserialize_type<'de, D>(
     deserializer: D,
     expected: &str,
 ) -> std::result::Result<String, D::Error>
@@ -165,7 +169,11 @@ where
     }
 }
 
-pub(crate) fn serialize_type<S>(
+/// Utility function to serialize the type field on an object.
+///
+/// Use this, via a wrapper function, in `#[serde(serialize_with)]`.  See [Item]
+/// for one example.
+pub fn serialize_type<S>(
     r#type: &String,
     serializer: S,
     expected: &str,


### PR DESCRIPTION
## Description

We want to use it in *pgstac-rs*.

## Checklist

- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
